### PR TITLE
Fix Clay 1.5 factory for downstream tasks

### DIFF
--- a/terratorch/models/clay1_5_model_factory.py
+++ b/terratorch/models/clay1_5_model_factory.py
@@ -29,6 +29,11 @@ SUPPORTED_TASKS = PIXEL_WISE_TASKS + SCALAR_TASKS
 # These are ignored when building the terratorch decoder kwargs.
 _CLAY_DECODER_KEYS = {"dim", "depth", "heads", "dim_head", "mlp_ratio", "ratio"}
 
+
+def _strip_clay_keys(kwargs: dict) -> dict:
+    return {k: v for k, v in kwargs.items() if k not in _CLAY_DECODER_KEYS}
+
+
 logger = logging.getLogger("terratorch")
 
 
@@ -170,10 +175,7 @@ class Clay1_5ModelFactory(ModelFactory):
 
         decoder_cls = _get_decoder(decoder)
         decoder_kwargs, _ = extract_prefix_keys(kwargs, "decoder_")
-        # Remove Clay v1.5 internal decoder keys that conflict with the decoder_ prefix
-        for clay_key in _CLAY_DECODER_KEYS:
-            decoder_kwargs.pop(clay_key, None)
-        decoder_instance = decoder_cls(feature_channels, **decoder_kwargs)
+        decoder_instance = decoder_cls(feature_channels, **_strip_clay_keys(decoder_kwargs))
 
         head_kwargs, _ = extract_prefix_keys(kwargs, "head_")
         if num_classes:
@@ -190,9 +192,7 @@ class Clay1_5ModelFactory(ModelFactory):
             args = aux_decoder.decoder_args if aux_decoder.decoder_args else {}
             aux_decoder_cls = _get_decoder(aux_decoder.decoder)
             aux_decoder_kwargs, _ = extract_prefix_keys(args, "decoder_")
-            for clay_key in _CLAY_DECODER_KEYS:
-                aux_decoder_kwargs.pop(clay_key, None)
-            aux_decoder_instance = aux_decoder_cls(feature_channels, **aux_decoder_kwargs)
+            aux_decoder_instance = aux_decoder_cls(feature_channels, **_strip_clay_keys(aux_decoder_kwargs))
             aux_head_kwargs, _ = extract_prefix_keys(args, "head_")
             if num_classes:
                 aux_head_kwargs["num_classes"] = num_classes
@@ -229,15 +229,16 @@ def _load_encoder_weights(encoder: nn.Module, ckpt_path: str) -> None:
     logger.info(f"Loading encoder weights from {ckpt_path}")
     checkpoint = torch.load(ckpt_path, map_location="cpu")
     state_dict = checkpoint.get("state_dict", checkpoint)
-    # Clay v1.5 checkpoints store the full ClayMAE; extract only encoder weights
+    # Clay v1.5 checkpoints store the full ClayMAE under "model.encoder.*"
+    prefix = "model.encoder."
     encoder_state = {
-        k[len("encoder."):]: v
+        k[len(prefix):]: v
         for k, v in state_dict.items()
-        if k.startswith("encoder.")
+        if k.startswith(prefix)
     }
     if not encoder_state:
         logger.warning(
-            "No keys with prefix 'encoder.' found in checkpoint. "
+            f"No keys with prefix '{prefix}' found in checkpoint. "
             "The encoder weights were NOT loaded. Keys found: "
             f"{list(state_dict.keys())[:10]} ..."
         )
@@ -267,7 +268,7 @@ def _build_appropriate_model(
             patch_size=patch_size, padding=padding, rescale=rescale,
             auxiliary_heads=auxiliary_heads,
         )
-    elif task in SCALAR_TASKS:
+    if task in SCALAR_TASKS:
         # rescale is not passed: ScalarOutputModel does not do spatial output
         return ScalarOutputModel(
             task, backbone, decoder, head_kwargs,

--- a/terratorch/models/clay1_5_model_factory.py
+++ b/terratorch/models/clay1_5_model_factory.py
@@ -1,18 +1,18 @@
-import importlib
 import logging
-import sys
+import math
 from collections.abc import Callable
+from pathlib import Path
 
-import timm
 import torch
-from box import Box
+from einops import repeat
 from torch import nn
+from box import Box
 
 import terratorch.models.decoders as decoder_registry
-from terratorch.models.backbones.clay_v1.embedder import Embedder
-from terratorch.models.backbones.clay_v15.model import ClayMAE
+from terratorch.models.backbones.clay_v15.model import Encoder
 from terratorch.models.model import (
     AuxiliaryHead,
+    AuxiliaryHeadWithDecoderWithoutInstantiatedHead,
     Model,
     ModelFactory,
 )
@@ -25,38 +25,54 @@ PIXEL_WISE_TASKS = ["segmentation", "regression"]
 SCALAR_TASKS = ["classification", "scalar_regression"]
 SUPPORTED_TASKS = PIXEL_WISE_TASKS + SCALAR_TASKS
 
+# ClayMAE checkpoint keys that collide with the terratorch decoder_ prefix convention.
+# These are ignored when building the terratorch decoder kwargs.
+_CLAY_DECODER_KEYS = {"dim", "depth", "heads", "dim_head", "mlp_ratio", "ratio"}
 
-class DecoderNotFoundError(Exception):
-    pass
+logger = logging.getLogger("terratorch")
 
 
-class ModelWrapper(nn.Module):
-    def __init__(self, batch_size, bands, platform, model: nn.Module = None) -> None:
+class ClayMAEBackbone(nn.Module):
+    """Wraps the Clay v1.5 Encoder as a feature extractor for downstream tasks.
 
+    Runs the encoder without masking to produce full spatial feature maps,
+    compatible with Terratorch's PixelWiseModel / ScalarOutputModel pipelines.
+    """
+
+    def __init__(self, encoder: nn.Module, platform: str | list[str], metadata: Box):
         super().__init__()
-        self.batch_size = batch_size
-        self.bands = bands
-        self.platform = platform
-        self.model = model
+        self.encoder_module = encoder
+        self.platform = platform[0] if isinstance(platform, list) else platform
+        self.metadata = metadata
+        self.patch_size = encoder.patch_size
+        self.dim = encoder.dim
 
-        # self.embedding_shape = self.model.state_dict()['decoder.embed_to_pixels.dem.bias'].shape[0]
+    def forward(self, x: torch.Tensor, **kwargs) -> list[torch.Tensor]:
+        B, C, H, W = x.shape
 
-    def channels(self):
-        return (1, self.embedding_shape)
+        waves = torch.tensor(
+            list(self.metadata[self.platform].bands.wavelength.values()),
+            device=x.device,
+        )
+        gsd = torch.tensor(self.metadata[self.platform].gsd, device=x.device)
+        time = torch.zeros(B, 4, device=x.device)
+        latlon = torch.zeros(B, 4, device=x.device)
 
-    @property
-    def parameters(self):
-        return self.model.parameters
+        # Patch embedding + positional encoding (no masking for downstream tasks)
+        patches, _ = self.encoder_module.to_patch_embed(x, waves)
+        patches = self.encoder_module.add_encodings(patches, time, latlon, gsd)
 
-    def forward(self, args, **kwargs):
-        datacube = {}
-        datacube["pixels"] = args
-        datacube["time"] = torch.zeros(self.batch_size, 4)
-        datacube["platform"] = self.platform
-        datacube["latlon"] = torch.zeros(self.batch_size, 4)
-        datacube["waves"] = torch.zeros(4)
-        datacube["gsd"] = torch.tensor(10)
-        return self.model.forward(datacube, **kwargs)
+        # Prepend CLS token and pass through transformer
+        cls_tokens = repeat(self.encoder_module.cls_token, "1 1 D -> B 1 D", B=B)
+        patches = torch.cat((cls_tokens, patches), dim=1)
+        encoded = self.encoder_module.transformer(patches)  # [B, 1+L, D]
+
+        # Strip CLS token and reshape to spatial [B, D, H', W']
+        features = encoded[:, 1:, :]  # [B, L, D]
+        grid_size = int(math.sqrt(features.shape[1]))
+        features = features.transpose(1, 2).reshape(B, self.dim, grid_size, grid_size)
+
+        return [features]
 
 
 @MODEL_FACTORY_REGISTRY.register
@@ -74,16 +90,201 @@ class Clay1_5ModelFactory(ModelFactory):
         prepare_features_for_image_model: Callable | None = None,
         aux_decoders: list[AuxiliaryHead] | None = None,
         rescale: bool = True,  # noqa: FBT002, FBT001
-        checkpoint_path: str = None,
+        checkpoint_path: str | None = None,
         **kwargs,
     ) -> Model:
-        # try:
-        #     from claymodel.model import ClayMAE
-        # except ImportError:
-        #     message = "clay v1.5 not installed, please use pip install claimodel"
-        #     logging.getLogger("terratorch").debug(message)
-        #    raise Exception(message)
-        batch_size = kwargs.get("batch_size")
+        """Model factory for Clay v1.5 downstream tasks.
+
+        Builds a full encoder-decoder model using the Clay v1.5 encoder as backbone,
+        wrapped in Terratorch's standard PixelWiseModel or ScalarOutputModel pipeline.
+
+        Required kwargs:
+            metadata (dict): Platform metadata containing band wavelengths and GSD.
+            platform (str | list[str]): Platform name matching a key in metadata.
+            dim (int): Encoder embedding dimension.
+            depth (int): Number of transformer layers.
+            heads (int): Number of attention heads.
+            dim_head (int): Dimension per attention head.
+            mlp_ratio (float): MLP hidden dim multiplier.
+            patch_size (int): Patch size for the convolutional embedding.
+
+        Optional kwargs:
+            mask_ratio (float): Unused for inference; kept for compatibility. Default 0.75.
+            shuffle (bool): Unused for inference; kept for compatibility. Default False.
+            padding (str): Padding mode for PixelWiseModel. Default "reflect".
+            batch_size (int): Ignored; accepted for backward compatibility.
+            decoder_* (kwargs): Passed to the terratorch decoder constructor.
+                Note: Clay v1.5 internal keys (decoder_dim, decoder_depth, decoder_heads,
+                decoder_dim_head, decoder_mlp_ratio) are silently ignored.
+
+        Args:
+            task: One of "segmentation", "regression", "classification", "scalar_regression".
+            backbone: Ignored; kept for API compatibility with other factories.
+            decoder: Decoder class name (e.g. "FCNDecoder") or an nn.Module instance.
+            in_channels: Number of input channels.
+            bands: Band names; informational only.
+            num_classes: Number of output classes. Required for segmentation/classification.
+            pretrained: If True, loads weights from checkpoint_path or downloads from HuggingFace.
+            num_frames: Ignored; kept for API compatibility.
+            aux_decoders: Optional list of auxiliary decoder heads.
+            rescale: Rescale model output to input spatial size via bilinear interpolation.
+            checkpoint_path: Path to a local Clay v1.5 checkpoint (.ckpt or .pt).
+        """
+        task = task.lower()
+        if task not in SUPPORTED_TASKS:
+            msg = f"Task {task} not supported. Please choose one of {SUPPORTED_TASKS}"
+            raise NotImplementedError(msg)
+
         platform = kwargs.get("platform")
-        kwargs["metadata"] = Box(kwargs["metadata"])
-        return ModelWrapper(batch_size, bands, platform, ClayMAE(**kwargs))
+        if platform is None:
+            raise ValueError("'platform' is required in kwargs for Clay1_5ModelFactory")
+        metadata_raw = kwargs.get("metadata")
+        if metadata_raw is None:
+            raise ValueError("'metadata' is required in kwargs for Clay1_5ModelFactory")
+        metadata = Box(metadata_raw)
+        platform_str = platform[0] if isinstance(platform, list) else platform
+        if platform_str not in metadata:
+            raise KeyError(f"Platform '{platform_str}' not found in metadata. Available: {list(metadata.keys())}")
+
+        patch_size = kwargs.get("patch_size", 8)
+        padding = kwargs.get("padding", "reflect")
+
+        encoder = Encoder(
+            mask_ratio=kwargs.get("mask_ratio", 0.75),
+            patch_size=patch_size,
+            shuffle=kwargs.get("shuffle", False),
+            dim=kwargs["dim"],
+            depth=kwargs["depth"],
+            heads=kwargs["heads"],
+            dim_head=kwargs["dim_head"],
+            mlp_ratio=kwargs["mlp_ratio"],
+        )
+
+        if pretrained:
+            ckpt_path = _resolve_checkpoint(checkpoint_path)
+            if ckpt_path:
+                _load_encoder_weights(encoder, ckpt_path)
+
+        backbone_module = ClayMAEBackbone(encoder, platform, metadata)
+        feature_channels = [backbone_module.dim]
+
+        decoder_cls = _get_decoder(decoder)
+        decoder_kwargs, _ = extract_prefix_keys(kwargs, "decoder_")
+        # Remove Clay v1.5 internal decoder keys that conflict with the decoder_ prefix
+        for clay_key in _CLAY_DECODER_KEYS:
+            decoder_kwargs.pop(clay_key, None)
+        decoder_instance = decoder_cls(feature_channels, **decoder_kwargs)
+
+        head_kwargs, _ = extract_prefix_keys(kwargs, "head_")
+        if num_classes:
+            head_kwargs["num_classes"] = num_classes
+
+        if aux_decoders is None:
+            return _build_appropriate_model(
+                task, backbone_module, decoder_instance, head_kwargs,
+                patch_size=patch_size, padding=padding, rescale=rescale,
+            )
+
+        to_be_aux_decoders: list[AuxiliaryHeadWithDecoderWithoutInstantiatedHead] = []
+        for aux_decoder in aux_decoders:
+            args = aux_decoder.decoder_args if aux_decoder.decoder_args else {}
+            aux_decoder_cls = _get_decoder(aux_decoder.decoder)
+            aux_decoder_kwargs, _ = extract_prefix_keys(args, "decoder_")
+            for clay_key in _CLAY_DECODER_KEYS:
+                aux_decoder_kwargs.pop(clay_key, None)
+            aux_decoder_instance = aux_decoder_cls(feature_channels, **aux_decoder_kwargs)
+            aux_head_kwargs, _ = extract_prefix_keys(args, "head_")
+            if num_classes:
+                aux_head_kwargs["num_classes"] = num_classes
+            to_be_aux_decoders.append(
+                AuxiliaryHeadWithDecoderWithoutInstantiatedHead(
+                    aux_decoder.name, aux_decoder_instance, aux_head_kwargs
+                )
+            )
+
+        return _build_appropriate_model(
+            task, backbone_module, decoder_instance, head_kwargs,
+            patch_size=patch_size, padding=padding, rescale=rescale,
+            auxiliary_heads=to_be_aux_decoders,
+        )
+
+
+def _resolve_checkpoint(checkpoint_path: str | None) -> str | None:
+    if checkpoint_path is not None:
+        path = Path(checkpoint_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Checkpoint not found: {checkpoint_path}")
+        return str(path)
+    # No explicit path provided — try HuggingFace
+    try:
+        from huggingface_hub import hf_hub_download
+        logger.info("Downloading Clay v1.5 checkpoint from HuggingFace...")
+        return hf_hub_download(repo_id="made-with-clay/Clay", filename="v1.5/clay-v1.5.ckpt")
+    except Exception as e:
+        logger.warning(f"Could not load pretrained weights: {e}")
+        return None
+
+
+def _load_encoder_weights(encoder: nn.Module, ckpt_path: str) -> None:
+    logger.info(f"Loading encoder weights from {ckpt_path}")
+    checkpoint = torch.load(ckpt_path, map_location="cpu")
+    state_dict = checkpoint.get("state_dict", checkpoint)
+    # Clay v1.5 checkpoints store the full ClayMAE; extract only encoder weights
+    encoder_state = {
+        k[len("encoder."):]: v
+        for k, v in state_dict.items()
+        if k.startswith("encoder.")
+    }
+    if not encoder_state:
+        logger.warning(
+            "No keys with prefix 'encoder.' found in checkpoint. "
+            "The encoder weights were NOT loaded. Keys found: "
+            f"{list(state_dict.keys())[:10]} ..."
+        )
+        return
+    missing, unexpected = encoder.load_state_dict(encoder_state, strict=False)
+    if missing:
+        logger.warning(f"Missing encoder keys: {missing}")
+    if unexpected:
+        logger.warning(f"Unexpected encoder keys: {unexpected}")
+    if not missing:
+        logger.info("Encoder weights loaded successfully")
+
+
+def _build_appropriate_model(
+    task: str,
+    backbone: nn.Module,
+    decoder: nn.Module,
+    head_kwargs: dict,
+    patch_size: int | None,
+    padding: str,
+    rescale: bool = True,
+    auxiliary_heads=None,
+):
+    if task in PIXEL_WISE_TASKS:
+        return PixelWiseModel(
+            task, backbone, decoder, head_kwargs,
+            patch_size=patch_size, padding=padding, rescale=rescale,
+            auxiliary_heads=auxiliary_heads,
+        )
+    elif task in SCALAR_TASKS:
+        # rescale is not passed: ScalarOutputModel does not do spatial output
+        return ScalarOutputModel(
+            task, backbone, decoder, head_kwargs,
+            patch_size=patch_size, padding=padding,
+            auxiliary_heads=auxiliary_heads,
+        )
+    raise AssertionError(f"Unreachable: unexpected task '{task}'")
+
+
+def _get_decoder(decoder: str | nn.Module) -> nn.Module:
+    if isinstance(decoder, nn.Module):
+        return decoder
+    if isinstance(decoder, str):
+        try:
+            return getattr(decoder_registry, decoder)
+        except AttributeError as e:
+            msg = f"Decoder {decoder} was not found in the registry."
+            raise DecoderNotFoundError(msg) from e
+    msg = "Decoder must be str or nn.Module"
+    raise Exception(msg)

--- a/tests/test_clay_1_5.py
+++ b/tests/test_clay_1_5.py
@@ -52,16 +52,7 @@ BASE_FACTORY_KWARGS = dict(
 
 
 def _make_encoder() -> Encoder:
-    return Encoder(
-        mask_ratio=0.75,
-        patch_size=TINY_ENCODER_KWARGS["patch_size"],
-        shuffle=False,
-        dim=TINY_ENCODER_KWARGS["dim"],
-        depth=TINY_ENCODER_KWARGS["depth"],
-        heads=TINY_ENCODER_KWARGS["heads"],
-        dim_head=TINY_ENCODER_KWARGS["dim_head"],
-        mlp_ratio=TINY_ENCODER_KWARGS["mlp_ratio"],
-    )
+    return Encoder(mask_ratio=0.75, shuffle=False, **TINY_ENCODER_KWARGS)
 
 
 def _make_backbone() -> ClayMAEBackbone:
@@ -85,14 +76,6 @@ class TestClayMAEBackbone:
         assert backbone.platform == "naip"
         assert backbone.dim == TINY_ENCODER_KWARGS["dim"]
         assert backbone.patch_size == TINY_ENCODER_KWARGS["patch_size"]
-
-    def test_platform_list_is_unwrapped(self):
-        backbone = ClayMAEBackbone(
-            encoder=_make_encoder(),
-            platform=["naip"],
-            metadata=Box(NAIP_METADATA),
-        )
-        assert backbone.platform == "naip"
 
     def test_platform_string_accepted(self):
         backbone = ClayMAEBackbone(
@@ -487,8 +470,8 @@ class TestCheckpointLoading:
     def test_load_encoder_weights_wrong_prefix_warns(self, tmp_path, caplog):
         import logging
         from terratorch.models.clay1_5_model_factory import _load_encoder_weights
-        # Checkpoint with wrong key prefix — no "encoder." keys
-        fake_state = {"model.encoder.some_weight": torch.zeros(4)}
+        # Checkpoint with wrong key prefix — no "model.encoder." keys
+        fake_state = {"encoder.some_weight": torch.zeros(4)}
         ckpt_path = tmp_path / "wrong_prefix.ckpt"
         torch.save({"state_dict": fake_state}, str(ckpt_path))
         encoder = _make_encoder()
@@ -500,9 +483,9 @@ class TestCheckpointLoading:
         import logging
         from terratorch.models.clay1_5_model_factory import _load_encoder_weights
         encoder = _make_encoder()
-        # Build a checkpoint using the real encoder state dict (all keys match)
+        # Real Clay v1.5 checkpoint layout: "model.encoder.<key>"
         encoder_state = encoder.state_dict()
-        full_state = {f"encoder.{k}": v for k, v in encoder_state.items()}
+        full_state = {f"model.encoder.{k}": v for k, v in encoder_state.items()}
         ckpt_path = tmp_path / "correct.ckpt"
         torch.save({"state_dict": full_state}, str(ckpt_path))
         with caplog.at_level(logging.INFO, logger="terratorch"):

--- a/tests/test_clay_1_5.py
+++ b/tests/test_clay_1_5.py
@@ -1,146 +1,515 @@
-import gc
+"""Tests for Clay v1.5 model factory and backbone adapter.
+
+Covers ClayMAEBackbone (the encoder wrapper) and Clay1_5ModelFactory
+for segmentation, regression, and classification tasks.
+"""
+
+import pytest
 import torch
-from torchvision.transforms import v2
-from terratorch.models.clay1_5_model_factory import Clay1_5ModelFactory
+from box import Box
+
+from terratorch.models.clay1_5_model_factory import Clay1_5ModelFactory, ClayMAEBackbone
+from terratorch.models.backbones.clay_v15.model import Encoder
+from terratorch.models.model import ModelOutput
+from terratorch.models.pixel_wise_model import PixelWiseModel
+from terratorch.models.scalar_output_model import ScalarOutputModel
 
 
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
 
-def test_create_model():
-
-    # with open("../model/configs/metadata.yaml", "r") as f:
-    #     metadata_contents = yaml.safe_load(f)
-
-    #print(metadata_contents['sentinel-2-l2a']['bands'])
-
-    #print(metadata_contents['sentinel-2-l2a'].bands.wavelength.values())
-    
-    model_args = {
-        # ENCODER
-        "dim": 192,
-        "depth": 6,
-        "heads": 4,
-        "dim_head": 48,
-        "mlp_ratio": 2,
-        # DECODER
-        "decoder_dim": 96,
-        "decoder_depth": 3,
-        "decoder_heads": 2,
-        "decoder_dim_head": 48,
-        "decoder_mlp_ratio": 2,
-        "mask_ratio": 0.75,
-        "norm_pix_loss": False,
-        "patch_size": 8,
-        "shuffle": True,
-        "metadata": {
-            "sentinel-2-l2a": {
-                "band_order": ["blue", "green", "red", "rededge1", "rededge2", "rededge3", "nir", "nir08", "swir16", "swir22"],
-                "rgb_indices": [2, 1, 0],
-                "gsd": 10,
-                "bands": {
-                    "mean": {"blue": 1105., "green": 1355., "red": 1552., "rededge1": 1887., "rededge2": 2422., "rededge3": 2630., "nir": 2743., "nir08": 2785., "swir16": 2388., "swir22": 1835.},
-                    "std": {"blue": 1809., "green": 1757., "red": 1888., "rededge1": 1870., "rededge2": 1732., "rededge3": 1697., "nir": 1742., "nir08": 1648., "swir16": 1470., "swir22": 1379.},
-                    "wavelength": {"blue": 0.493, "green": 0.56, "red": 0.665, "rededge1": 0.704, "rededge2": 0.74, "rededge3": 0.783, "nir": 0.842, "nir08": 0.865, "swir16": 1.61, "swir22": 2.19}
-                }
-            },
-            "planetscope-sr": {
-                "band_order": ["coastal_blue", "blue", "green_i", "green", "yellow", "red", "rededge", "nir"],
-                "rgb_indices": [5, 3, 1],
-                "gsd": 5,
-                "bands": {
-                    "mean": {"coastal_blue": 1720., "blue": 1715., "green_i": 1913., "green": 2088., "yellow": 2274., "red": 2290., "rededge": 2613., "nir": 3970.},
-                    "std": {"coastal_blue": 747., "blue": 698., "green_i": 739., "green": 768., "yellow": 849., "red": 868., "rededge": 849., "nir": 914.},
-                    "wavelength": {"coastal_blue": 0.443, "blue": 0.490, "green_i": 0.531, "green": 0.565, "yellow": 0.610, "red": 0.665, "rededge": 0.705, "nir": 0.865}
-                }
-            },
-            "landsat-c2l1": {
-                "band_order": ["red", "green", "blue", "nir08", "swir16", "swir22"],
-                "rgb_indices": [0, 1, 2],
-                "gsd": 30,
-                "bands": {
-                    "mean": {"red": 10678., "green": 10563., "blue": 11083., "nir08": 14792., "swir16": 12276., "swir22": 10114.},
-                    "std": {"red": 6025., "green": 5411., "blue": 5468., "nir08": 6746., "swir16": 5897., "swir22": 4850.},
-                    "wavelength": {"red": 0.65, "green": 0.56, "blue": 0.48, "nir08": 0.86, "swir16": 1.6, "swir22": 2.2}
-                }
-            },
-            "landsat-c2l2-sr": {
-                "band_order": ["red", "green", "blue", "nir08", "swir16", "swir22"],
-                "rgb_indices": [0, 1, 2],
-                "gsd": 30,
-                "bands": {
-                    "mean": {"red": 13705., "green": 13310., "blue": 12474., "nir08": 17801., "swir16": 14615., "swir22": 12701.},
-                    "std": {"red": 9578., "green": 9408., "blue": 10144., "nir08": 8277., "swir16": 5300., "swir22": 4522.},
-                    "wavelength": {"red": 0.65, "green": 0.56, "blue": 0.48, "nir08": 0.86, "swir16": 1.6, "swir22": 2.2}
-                }
-            },
-            "naip": {
-                "band_order": ["red", "green", "blue", "nir"],
-                "rgb_indices": [0, 1, 2],
-                "gsd": 1.0,
-                "bands": {
-                    "mean": {"red": 110.16, "green": 115.41, "blue": 98.15, "nir": 139.04},
-                    "std": {"red": 47.23, "green": 39.82, "blue": 35.43, "nir": 49.86},
-                    "wavelength": {"red": 0.65, "green": 0.56, "blue": 0.48, "nir": 0.842}
-                }
-            },
-            "linz": {
-                "band_order": ["red", "green", "blue"],
-                "rgb_indices": [0, 1, 2],
-                "gsd": 0.5,
-                "bands": {
-                    "mean": {"red": 89.96, "green": 99.46, "blue": 89.51},
-                    "std": {"red": 41.83, "green": 36.96, "blue": 31.45},
-                    "wavelength": {"red": 0.635, "green": 0.555, "blue": 0.465}
-                }
-            },
-            "sentinel-1-rtc": {
-                "band_order": ["vv", "vh"],
-                "gsd": 10,
-                "bands": {
-                    "mean": {"vv": -12.113, "vh": -18.673},
-                    "std": {"vv": 8.314, "vh": 8.017},
-                    "wavelength": {"vv": 3.5, "vh": 4.0}
-                }
-            },
-            "modis": {
-                "band_order": ["sur_refl_b01", "sur_refl_b02", "sur_refl_b03", "sur_refl_b04", "sur_refl_b05", "sur_refl_b06", "sur_refl_b07"],
-                "rgb_indices": [0, 3, 2],
-                "gsd": 500,
-                "bands": {
-                    "mean": {
-                        "sur_refl_b01": 1072., "sur_refl_b02": 1624., "sur_refl_b03": 931., "sur_refl_b04": 1023.,
-                        "sur_refl_b05": 1599., "sur_refl_b06": 1404., "sur_refl_b07": 1051.
-                    },
-                    "std": {
-                        "sur_refl_b01": 1643., "sur_refl_b02": 1878., "sur_refl_b03": 1449., "sur_refl_b04": 1538.,
-                        "sur_refl_b05": 1763., "sur_refl_b06": 1618., "sur_refl_b07": 1396.
-                    },
-                    "wavelength": {
-                        "sur_refl_b01": .645, "sur_refl_b02": .858, "sur_refl_b03": .469, "sur_refl_b04": .555,
-                        "sur_refl_b05": 1.240, "sur_refl_b06": 1.640, "sur_refl_b07": 2.130
-                    }
-                }
-            }
+NAIP_METADATA = {
+    "naip": {
+        "band_order": ["red", "green", "blue", "nir"],
+        "rgb_indices": [0, 1, 2],
+        "gsd": 1.0,
+        "bands": {
+            "mean": {"red": 110.16, "green": 115.41, "blue": 98.15, "nir": 139.04},
+            "std": {"red": 47.23, "green": 39.82, "blue": 35.43, "nir": 49.86},
+            "wavelength": {"red": 0.65, "green": 0.56, "blue": 0.48, "nir": 0.842},
         },
-        "teacher": "vit_large_patch14_reg4_dinov2.lvd142m",
-        "dolls": [16, 32, 64, 128, 256, 768, 1024],
-        "doll_weights": [1, 1, 1, 1, 1, 1, 1],
-        "in_channels": None,
-        "batch_size": 1,
-        "platform": ["sentinel-2-l2a"]
     }
+}
 
-    clay_model = Clay1_5ModelFactory().build_model(1, 3, ["sentinel-2-l2a"], **model_args)
-    # data_cube = {
-    #     "pixels": torch.randn(64, 10, 64, 64), 
-    #     "time": torch.stack([torch.zeros(4) for _ in range(64)]),
-    #     "platform": ["sentinel-2-l2a"],
-    #     "latlon": torch.zeros(64,4),
-    #     "waves": torch.zeros(4),
-    #     "gsd": torch.tensor(10),
-    # }
+# Tiny encoder config so tests run fast without a GPU
+TINY_ENCODER_KWARGS = dict(
+    dim=64,
+    depth=2,
+    heads=2,
+    dim_head=32,
+    mlp_ratio=2,
+    patch_size=8,
+)
 
-    # clay_model.forward(data_cube)
-    clay_model.forward(torch.randn(1, 10, 224, 224))
+# Minimal kwargs for the factory (no pretrained weights, no HuggingFace download)
+BASE_FACTORY_KWARGS = dict(
+    **TINY_ENCODER_KWARGS,
+    metadata=NAIP_METADATA,
+    platform=["naip"],
+    pretrained=False,
+)
 
-    gc.collect()
 
+def _make_encoder() -> Encoder:
+    return Encoder(
+        mask_ratio=0.75,
+        patch_size=TINY_ENCODER_KWARGS["patch_size"],
+        shuffle=False,
+        dim=TINY_ENCODER_KWARGS["dim"],
+        depth=TINY_ENCODER_KWARGS["depth"],
+        heads=TINY_ENCODER_KWARGS["heads"],
+        dim_head=TINY_ENCODER_KWARGS["dim_head"],
+        mlp_ratio=TINY_ENCODER_KWARGS["mlp_ratio"],
+    )
+
+
+def _make_backbone() -> ClayMAEBackbone:
+    return ClayMAEBackbone(
+        encoder=_make_encoder(),
+        platform=["naip"],
+        metadata=Box(NAIP_METADATA),
+    )
+
+
+# ---------------------------------------------------------------------------
+# ClayMAEBackbone tests
+# ---------------------------------------------------------------------------
+
+class TestClayMAEBackbone:
+    """Tests for the ClayMAEBackbone encoder adapter."""
+
+    def test_initialization(self):
+        backbone = _make_backbone()
+
+        assert backbone.platform == "naip"
+        assert backbone.dim == TINY_ENCODER_KWARGS["dim"]
+        assert backbone.patch_size == TINY_ENCODER_KWARGS["patch_size"]
+
+    def test_platform_list_is_unwrapped(self):
+        backbone = ClayMAEBackbone(
+            encoder=_make_encoder(),
+            platform=["naip"],
+            metadata=Box(NAIP_METADATA),
+        )
+        assert backbone.platform == "naip"
+
+    def test_platform_string_accepted(self):
+        backbone = ClayMAEBackbone(
+            encoder=_make_encoder(),
+            platform="naip",
+            metadata=Box(NAIP_METADATA),
+        )
+        assert backbone.platform == "naip"
+
+    def test_forward_returns_list(self):
+        backbone = _make_backbone()
+        x = torch.randn(1, 4, 64, 64)
+        out = backbone(x)
+
+        assert isinstance(out, list)
+        assert len(out) == 1
+
+    def test_forward_output_shape(self):
+        backbone = _make_backbone()
+        B, C, H, W = 1, 4, 64, 64
+        x = torch.randn(B, C, H, W)
+        out = backbone(x)
+
+        expected_grid = H // TINY_ENCODER_KWARGS["patch_size"]
+        assert out[0].shape == (B, TINY_ENCODER_KWARGS["dim"], expected_grid, expected_grid)
+
+    def test_forward_batch_size_greater_than_one(self):
+        """Core regression test: the original fix had a bug where only batch_size=1 worked
+        because encoded_patches[-1] indexed the last batch item instead of removing the
+        CLS token. This test ensures the fix works for any batch size."""
+        backbone = _make_backbone()
+        for batch_size in [1, 2, 4]:
+            x = torch.randn(batch_size, 4, 64, 64)
+            out = backbone(x)
+            expected_grid = 64 // TINY_ENCODER_KWARGS["patch_size"]
+            assert out[0].shape == (batch_size, TINY_ENCODER_KWARGS["dim"], expected_grid, expected_grid), \
+                f"Wrong shape for batch_size={batch_size}"
+
+    def test_forward_output_is_finite(self):
+        backbone = _make_backbone()
+        x = torch.randn(2, 4, 64, 64)
+        out = backbone(x)
+        assert torch.isfinite(out[0]).all()
+
+    def test_forward_feature_count_matches_all_patches(self):
+        """Spatial grid must equal full unmasked patch count (not a masked subset)."""
+        backbone = _make_backbone()
+        H, W = 64, 64
+        patch_size = TINY_ENCODER_KWARGS["patch_size"]
+        x = torch.randn(1, 4, H, W)
+        with torch.no_grad():
+            out = backbone(x)
+        features = out[0]
+        assert features.shape[2] * features.shape[3] == (H // patch_size) * (W // patch_size)
+
+    def test_gradient_flow(self):
+        backbone = _make_backbone()
+        x = torch.randn(2, 4, 64, 64, requires_grad=True)
+        out = backbone(x)
+        loss = out[0].sum()
+        loss.backward()
+
+        assert x.grad is not None
+        assert not torch.all(x.grad == 0)
+
+    def test_eval_mode_deterministic(self):
+        backbone = _make_backbone()
+        backbone.eval()
+        x = torch.randn(1, 4, 64, 64)
+        with torch.no_grad():
+            out1 = backbone(x)
+            out2 = backbone(x)
+        assert torch.allclose(out1[0], out2[0])
+
+    def test_batch_independence(self):
+        """Each sample in a batch should be processed independently."""
+        backbone = _make_backbone()
+        backbone.eval()
+        x1 = torch.randn(1, 4, 64, 64)
+        x2 = torch.randn(1, 4, 64, 64)
+        x_batched = torch.cat([x1, x2], dim=0)
+
+        with torch.no_grad():
+            out1 = backbone(x1)
+            out2 = backbone(x2)
+            out_batched = backbone(x_batched)
+
+        assert torch.allclose(out_batched[0][0], out1[0][0], atol=1e-5)
+        assert torch.allclose(out_batched[0][1], out2[0][0], atol=1e-5)
+
+    def test_different_spatial_sizes(self):
+        backbone = _make_backbone()
+        for h, w in [(64, 64), (128, 128)]:
+            x = torch.randn(1, 4, h, w)
+            out = backbone(x)
+            expected_grid_h = h // TINY_ENCODER_KWARGS["patch_size"]
+            expected_grid_w = w // TINY_ENCODER_KWARGS["patch_size"]
+            assert out[0].shape == (1, TINY_ENCODER_KWARGS["dim"], expected_grid_h, expected_grid_w)
+
+
+# ---------------------------------------------------------------------------
+# Clay1_5ModelFactory tests
+# ---------------------------------------------------------------------------
+
+class TestClay1_5ModelFactory:
+    """Tests for Clay1_5ModelFactory.build_model()."""
+
+    @pytest.fixture
+    def factory(self):
+        return Clay1_5ModelFactory()
+
+    def test_segmentation_returns_pixel_wise_model(self, factory):
+        model = factory.build_model(
+            task="segmentation",
+            backbone="clay15",
+            decoder="FCNDecoder",
+            in_channels=4,
+            num_classes=10,
+            **BASE_FACTORY_KWARGS,
+        )
+        assert isinstance(model, PixelWiseModel)
+
+    def test_regression_returns_pixel_wise_model(self, factory):
+        model = factory.build_model(
+            task="regression",
+            backbone="clay15",
+            decoder="FCNDecoder",
+            in_channels=4,
+            **BASE_FACTORY_KWARGS,
+        )
+        assert isinstance(model, PixelWiseModel)
+
+    def test_classification_returns_scalar_output_model(self, factory):
+        model = factory.build_model(
+            task="classification",
+            backbone="clay15",
+            decoder="FCNDecoder",
+            in_channels=4,
+            num_classes=5,
+            **BASE_FACTORY_KWARGS,
+        )
+        assert isinstance(model, ScalarOutputModel)
+
+    def test_unsupported_task_raises(self, factory):
+        with pytest.raises(NotImplementedError):
+            factory.build_model(
+                task="invalid_task",
+                backbone="clay15",
+                decoder="FCNDecoder",
+                in_channels=4,
+                **BASE_FACTORY_KWARGS,
+            )
+
+    def test_task_is_case_insensitive(self, factory):
+        model = factory.build_model(
+            task="SEGMENTATION",
+            backbone="clay15",
+            decoder="FCNDecoder",
+            in_channels=4,
+            num_classes=10,
+            **BASE_FACTORY_KWARGS,
+        )
+        assert isinstance(model, PixelWiseModel)
+
+    def test_invalid_decoder_raises(self, factory):
+        with pytest.raises(Exception):
+            factory.build_model(
+                task="segmentation",
+                backbone="clay15",
+                decoder="NonExistentDecoder",
+                in_channels=4,
+                num_classes=10,
+                **BASE_FACTORY_KWARGS,
+            )
+
+    def test_backbone_is_clay_mae_backbone(self, factory):
+        model = factory.build_model(
+            task="segmentation",
+            backbone="clay15",
+            decoder="FCNDecoder",
+            in_channels=4,
+            num_classes=10,
+            **BASE_FACTORY_KWARGS,
+        )
+        assert isinstance(model.encoder, ClayMAEBackbone)
+
+    def test_scalar_regression_returns_scalar_output_model(self, factory):
+        model = factory.build_model(
+            task="scalar_regression",
+            backbone="clay15",
+            decoder="FCNDecoder",
+            in_channels=4,
+            num_classes=1,
+            **BASE_FACTORY_KWARGS,
+        )
+        assert isinstance(model, ScalarOutputModel)
+
+    def test_missing_platform_raises(self, factory):
+        kwargs = {k: v for k, v in BASE_FACTORY_KWARGS.items() if k != "platform"}
+        with pytest.raises(ValueError, match="platform"):
+            factory.build_model(
+                task="segmentation",
+                backbone="clay15",
+                decoder="FCNDecoder",
+                in_channels=4,
+                num_classes=10,
+                **kwargs,
+            )
+
+    def test_missing_metadata_raises(self, factory):
+        kwargs = {k: v for k, v in BASE_FACTORY_KWARGS.items() if k != "metadata"}
+        with pytest.raises(ValueError, match="metadata"):
+            factory.build_model(
+                task="segmentation",
+                backbone="clay15",
+                decoder="FCNDecoder",
+                in_channels=4,
+                num_classes=10,
+                **kwargs,
+            )
+
+    def test_platform_not_in_metadata_raises(self, factory):
+        with pytest.raises(KeyError):
+            factory.build_model(
+                task="segmentation",
+                backbone="clay15",
+                decoder="FCNDecoder",
+                in_channels=4,
+                num_classes=10,
+                **{**BASE_FACTORY_KWARGS, "platform": "nonexistent"},
+            )
+
+    def test_clay_internal_decoder_kwargs_ignored(self, factory):
+        """Old ClayMAE decoder kwargs (decoder_dim, decoder_depth, etc.) must not
+        cause errors — they should be silently dropped."""
+        model = factory.build_model(
+            task="segmentation",
+            backbone="clay15",
+            decoder="FCNDecoder",
+            in_channels=4,
+            num_classes=10,
+            # These are Clay v1.5 internal args that should be ignored
+            decoder_dim=96,
+            decoder_depth=3,
+            decoder_heads=2,
+            decoder_dim_head=48,
+            decoder_mlp_ratio=2,
+            **BASE_FACTORY_KWARGS,
+        )
+        assert isinstance(model, PixelWiseModel)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end forward pass tests
+# ---------------------------------------------------------------------------
+
+class TestClay1_5ModelFactoryForward:
+    """End-to-end forward pass tests for models built by Clay1_5ModelFactory."""
+
+    @pytest.fixture
+    def segmentation_model(self):
+        return Clay1_5ModelFactory().build_model(
+            task="segmentation",
+            backbone="clay15",
+            decoder="FCNDecoder",
+            in_channels=4,
+            num_classes=10,
+            **BASE_FACTORY_KWARGS,
+        )
+
+    def test_forward_returns_model_output(self, segmentation_model):
+        """The model must return a ModelOutput, not a tuple of losses."""
+        x = torch.randn(1, 4, 64, 64)
+        out = segmentation_model(x)
+        assert isinstance(out, ModelOutput)
+
+    def test_forward_output_has_correct_num_classes(self, segmentation_model):
+        x = torch.randn(1, 4, 64, 64)
+        out = segmentation_model(x)
+        assert out.output.shape[1] == 10
+
+    def test_forward_output_spatial_size_matches_input(self, segmentation_model):
+        """With rescale=True, output spatial dims should match input."""
+        H, W = 64, 64
+        x = torch.randn(1, 4, H, W)
+        out = segmentation_model(x)
+        assert out.output.shape[-2:] == (H, W)
+
+    def test_forward_batch_size_one(self, segmentation_model):
+        x = torch.randn(1, 4, 64, 64)
+        out = segmentation_model(x)
+        assert out.output.shape[0] == 1
+
+    def test_forward_batch_size_two(self, segmentation_model):
+        """Regression test for the batch_size > 1 bug in the original implementation."""
+        x = torch.randn(2, 4, 64, 64)
+        out = segmentation_model(x)
+        assert out.output.shape[0] == 2
+
+    def test_forward_output_is_finite(self, segmentation_model):
+        x = torch.randn(2, 4, 64, 64)
+        out = segmentation_model(x)
+        assert torch.isfinite(out.output).all()
+
+    def test_forward_gradient_flow(self, segmentation_model):
+        x = torch.randn(2, 4, 64, 64, requires_grad=True)
+        out = segmentation_model(x)
+        loss = out.output.sum()
+        loss.backward()
+        assert x.grad is not None
+        assert not torch.all(x.grad == 0)
+
+    def test_forward_regression_task(self):
+        model = Clay1_5ModelFactory().build_model(
+            task="regression",
+            backbone="clay15",
+            decoder="FCNDecoder",
+            in_channels=4,
+            **BASE_FACTORY_KWARGS,
+        )
+        x = torch.randn(2, 4, 64, 64)
+        out = model(x)
+        assert isinstance(out, ModelOutput)
+        assert torch.isfinite(out.output).all()
+
+    def test_forward_different_spatial_sizes(self, segmentation_model):
+        for h, w in [(64, 64), (128, 128)]:
+            x = torch.randn(1, 4, h, w)
+            out = segmentation_model(x)
+            assert out.output.shape[-2:] == (h, w), f"Failed for input size ({h},{w})"
+
+    def test_forward_eval_mode_deterministic(self, segmentation_model):
+        segmentation_model.eval()
+        x = torch.randn(1, 4, 64, 64)
+        with torch.no_grad():
+            out1 = segmentation_model(x)
+            out2 = segmentation_model(x)
+        assert torch.allclose(out1.output, out2.output)
+
+    def test_backward_compatible_with_extra_clay_kwargs(self):
+        """Old configs passing ClayMAE-specific kwargs should still work."""
+        model = Clay1_5ModelFactory().build_model(
+            task="segmentation",
+            backbone="clay15",
+            decoder="FCNDecoder",
+            in_channels=4,
+            num_classes=5,
+            # Legacy ClayMAE kwargs
+            mask_ratio=0.75,
+            norm_pix_loss=False,
+            shuffle=True,
+            teacher="vit_large_patch14_reg4_dinov2.lvd142m",
+            dolls=[16, 32, 64, 128, 256, 768, 1024],
+            doll_weights=[1, 1, 1, 1, 1, 1, 1],
+            batch_size=1,
+            decoder_dim=96,
+            decoder_depth=3,
+            decoder_heads=2,
+            decoder_dim_head=48,
+            decoder_mlp_ratio=2,
+            **BASE_FACTORY_KWARGS,
+        )
+        x = torch.randn(1, 4, 64, 64)
+        out = model(x)
+        assert isinstance(out, ModelOutput)
+        assert out.output.shape == (1, 5, 64, 64)
+
+    def test_model_is_in_training_mode_by_default(self, segmentation_model):
+        """Model should be in training mode after construction, ready for fine-tuning."""
+        assert segmentation_model.training is True
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint loading tests
+# ---------------------------------------------------------------------------
+
+class TestCheckpointLoading:
+    """Tests for _resolve_checkpoint and _load_encoder_weights."""
+
+    def test_resolve_checkpoint_valid_path(self, tmp_path):
+        from terratorch.models.clay1_5_model_factory import _resolve_checkpoint
+        ckpt = tmp_path / "fake.ckpt"
+        ckpt.write_bytes(b"")
+        result = _resolve_checkpoint(str(ckpt))
+        assert result == str(ckpt)
+
+    def test_resolve_checkpoint_invalid_path_raises(self):
+        from terratorch.models.clay1_5_model_factory import _resolve_checkpoint
+        with pytest.raises(FileNotFoundError, match="Checkpoint not found"):
+            _resolve_checkpoint("/nonexistent/path/model.ckpt")
+
+    def test_load_encoder_weights_wrong_prefix_warns(self, tmp_path, caplog):
+        import logging
+        from terratorch.models.clay1_5_model_factory import _load_encoder_weights
+        # Checkpoint with wrong key prefix — no "encoder." keys
+        fake_state = {"model.encoder.some_weight": torch.zeros(4)}
+        ckpt_path = tmp_path / "wrong_prefix.ckpt"
+        torch.save({"state_dict": fake_state}, str(ckpt_path))
+        encoder = _make_encoder()
+        with caplog.at_level(logging.WARNING, logger="terratorch"):
+            _load_encoder_weights(encoder, str(ckpt_path))
+        assert "NOT loaded" in caplog.text
+
+    def test_load_encoder_weights_correct_prefix(self, tmp_path, caplog):
+        import logging
+        from terratorch.models.clay1_5_model_factory import _load_encoder_weights
+        encoder = _make_encoder()
+        # Build a checkpoint using the real encoder state dict (all keys match)
+        encoder_state = encoder.state_dict()
+        full_state = {f"encoder.{k}": v for k, v in encoder_state.items()}
+        ckpt_path = tmp_path / "correct.ckpt"
+        torch.save({"state_dict": full_state}, str(ckpt_path))
+        with caplog.at_level(logging.INFO, logger="terratorch"):
+            _load_encoder_weights(encoder, str(ckpt_path))
+        assert "NOT loaded" not in caplog.text
+        assert "loaded successfully" in caplog.text
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Fix Clay1_5ModelFactory for downstream tasks (segmentation, regression, classification). Tested it on a local training on the [Habitalp2 dataset](https://huggingface.co/datasets/JR-DIGITAL/habitalp2.0/tree/main) and it performed slightly better than Clay 1.0. 

FYI @romeokienzler @BrunoSanchez

**Description**
As there was no progress on #970 I decided to take a stab on this myself. This should close the issue when merged. 
The original Clay1_5ModelFactory was broken for any downstream task: it instantiated the full ClayMAE Lightning module (which triggered a teacher ViT download) and returned MAE reconstruction losses instead of feature maps, making fine-tuning mpossible. 

**What changed**

- Replaced the full ClayMAE instantiation with a direct Encoder construction — no teacher ViT, no Lightning module, no HuggingFace download at build time.
- Added ClayMAEBackbone, a thin nn.Module wrapper that runs the encoder without masking to produce full spatial feature maps compatible with PixelWiseModel
/ ScalarOutputModel.
- Fixed a batch-size bug in the original implementation where encoded_patches[-1] indexed the last batch item instead of stripping the CLS token, silently
producing wrong results for batch_size > 1.
- Hardened checkpoint loading: explicit FileNotFoundError for bad paths, graceful warning if checkpoint keys don't match the expected model.encoder.*
prefix, fallback to HuggingFace if no path is given.
- Silently drops legacy ClayMAE decoder kwargs (decoder_dim, decoder_depth, etc.) so old configs don't break.
- 39 unit tests covering backbone forward pass, factory instantiation for all four task types, checkpoint loading edge cases, and end-to-end forward +
gradient flow.