### PR TITLE
fix: OlmoEarth backbone forward pass to match olmoearth_pretrain API

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'feature/**'
     paths-ignore:
       - 'docs/**'
       - '*.md'
@@ -93,6 +94,35 @@ jobs:
       - name: Test with pytest (slow)
         run: |
           pytest -s -v -m "slow" tests
+
+  olmoearth-tests:
+    environment: cicd
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      matrix:
+        python-version: ["3.13"]
+    env:
+      OMP_NUM_THREADS: "1"
+      MKL_NUM_THREADS: "1"
+      OPENBLAS_NUM_THREADS: "1"
+      NUMEXPR_NUM_THREADS: "1"
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v5
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          pip install pip==25.1
+          pip --version
+          pip install -e .[test,olmoearth]
+      - name: Test OlmoEarth integration
+        run: |
+          pytest -s -v tests/test_olmoearth.py
 
   rfdetr-tests:
     environment: cicd

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -119,8 +119,8 @@ jobs:
         run: |
           pip install pip==25.1
           pip --version
-          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -e .[test,olmoearth]
+          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu --force-reinstall --no-deps
       - name: Test OlmoEarth integration
         run: |
           pytest -s -v tests/test_olmoearth.py

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -119,6 +119,7 @@ jobs:
         run: |
           pip install pip==25.1
           pip --version
+          pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -e .[test,olmoearth]
       - name: Test OlmoEarth integration
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,6 +163,10 @@ tortilla = [
   "tacoreader==0.5.6",
 ]
 
+olmoearth = [
+  "olmoearth-pretrain>=0.1.0",
+]
+
 [project.urls]
 Documentation = "https://torchgeo.github.io/terratorch/"
 Issues = "https://github.com/torchgeo/terratorch/issues"

--- a/terratorch/models/backbones/__init__.py
+++ b/terratorch/models/backbones/__init__.py
@@ -19,3 +19,8 @@ try:
     import terratorch.models.backbones.heliofm_register
 except ImportError:
     pass
+
+try:
+    import terratorch.models.backbones.olmoearth
+except ImportError:
+    pass

--- a/terratorch/models/backbones/olmoearth.py
+++ b/terratorch/models/backbones/olmoearth.py
@@ -1,0 +1,351 @@
+# Copyright contributors to the Terratorch project
+# Licensed under the Apache License 2.0
+
+"""OlmoEarth backbone integration for TerraTorch.
+
+This module registers OlmoEarth (Allen AI) foundation models as backbones
+in the TerraTorch backbone registry. OlmoEarth is a spatio-temporal, multimodal
+foundation model for Earth observations supporting Sentinel-1, Sentinel-2, and Landsat.
+
+Requires the `olmoearth-pretrain` package:
+    pip install terratorch[olmoearth]
+
+References:
+    - GitHub: https://github.com/allenai/olmoearth_pretrain
+    - Paper: https://arxiv.org/abs/2511.13655
+"""
+
+import logging
+from collections.abc import Callable
+
+import torch
+from torch import Tensor, nn
+
+from terratorch.registry import TERRATORCH_BACKBONE_REGISTRY
+
+logger = logging.getLogger(__name__)
+
+
+# OlmoEarth model configurations
+# Maps terratorch model names -> (ModelID enum value, encoder embedding size)
+OLMOEARTH_CONFIGS: dict[str, dict] = {
+    "olmoearth_v1_nano": {
+        "model_id": "OlmoEarth-v1-Nano",
+        "embed_dim": 64,
+    },
+    "olmoearth_v1_tiny": {
+        "model_id": "OlmoEarth-v1-Tiny",
+        "embed_dim": 128,
+    },
+    "olmoearth_v1_base": {
+        "model_id": "OlmoEarth-v1-Base",
+        "embed_dim": 768,
+    },
+    "olmoearth_v1_large": {
+        "model_id": "OlmoEarth-v1-Large",
+        "embed_dim": 1024,
+    },
+    "olmoearth_v1_1_nano": {
+        "model_id": "OlmoEarth-v1_1-Nano",
+        "embed_dim": 128,
+    },
+    "olmoearth_v1_1_tiny": {
+        "model_id": "OlmoEarth-v1_1-Tiny",
+        "embed_dim": 192,
+    },
+    "olmoearth_v1_1_base": {
+        "model_id": "OlmoEarth-v1_1-Base",
+        "embed_dim": 768,
+    },
+    "olmoearth_v1_2_nano": {
+        "model_id": "OlmoEarth-v1_2-Nano",
+        "embed_dim": 128,
+    },
+    "olmoearth_v1_2_tiny": {
+        "model_id": "OlmoEarth-v1_2-Tiny",
+        "embed_dim": 192,
+    },
+    "olmoearth_v1_2_small": {
+        "model_id": "OlmoEarth-v1_2-Small",
+        "embed_dim": 384,
+    },
+    "olmoearth_v1_2_base": {
+        "model_id": "OlmoEarth-v1_2-Base",
+        "embed_dim": 768,
+    },
+}
+
+
+class OlmoEarthBackbone(nn.Module):
+    """Wrapper around OlmoEarth encoder for use as a TerraTorch backbone.
+
+    This wrapper loads an OlmoEarth model (encoder only) and adapts its
+    forward pass to produce a list of feature maps compatible with TerraTorch
+    decoders. The encoder's output embeddings are reshaped from (B, N, D) token
+    sequences to (B, D, H, W) spatial feature maps.
+
+    OlmoEarth's native interface expects a MaskedOlmoEarthSample input with
+    multi-modal data. This wrapper provides a simplified interface that accepts
+    a standard image tensor (B, C, H, W) and wraps it as Sentinel-2 input.
+    """
+
+    def __init__(
+        self,
+        model_id: str,
+        embed_dim: int,
+        pretrained: bool = True,
+        patch_size: int = 8,
+        input_res: int = 10,
+        modality: str = "sentinel2",
+        ckpt_path: str | None = None,
+    ):
+        """Initialize OlmoEarth backbone.
+
+        Args:
+            model_id: OlmoEarth model identifier (e.g. "OlmoEarth-v1-Base")
+            embed_dim: Embedding dimension of the encoder
+            pretrained: Whether to load pretrained weights from HuggingFace
+            patch_size: Patch size for tokenization (default 8)
+            input_res: Input resolution in meters (default 10m for Sentinel-2)
+            modality: Input modality name (default "sentinel2")
+            ckpt_path: Optional path to a local checkpoint file
+        """
+        super().__init__()
+
+        from olmoearth_pretrain.model_loader import ModelID, load_model_from_id, load_model_from_path
+
+        self.embed_dim = embed_dim
+        self.patch_size = patch_size
+        self.input_res = input_res
+        self.modality = modality
+
+        # Load the full model (encoder + decoder)
+        if ckpt_path is not None:
+            full_model = load_model_from_path(ckpt_path, load_weights=pretrained)
+        else:
+            model_id_enum = ModelID(model_id)
+            full_model = load_model_from_id(model_id_enum, load_weights=pretrained)
+
+        # Extract only the encoder
+        self.encoder = full_model.encoder
+
+        # Expose embedding dimension for downstream components
+        self.num_features = embed_dim
+
+    @property
+    def out_channels(self) -> list[int]:
+        """Return the output channel dimensions for each feature level.
+
+        OlmoEarth encoder produces a single feature level.
+        """
+        return [self.embed_dim]
+
+    def forward(self, x: Tensor) -> list[Tensor]:
+        """Forward pass through the OlmoEarth encoder.
+
+        Takes a standard (B, C, H, W) image tensor and returns a list of
+        spatial feature maps [(B, D, H', W')] suitable for TerraTorch decoders.
+
+        Args:
+            x: Input tensor of shape (B, C, H, W)
+
+        Returns:
+            List containing a single feature map of shape (B, embed_dim, H', W')
+            where H' = H // patch_size and W' = W // patch_size.
+        """
+        from olmoearth_pretrain.datatypes import MaskedOlmoEarthSample, MaskValue
+
+        B, C, H, W = x.shape
+
+        # Compute spatial grid dimensions after patchification
+        h_patches = H // self.patch_size
+        w_patches = W // self.patch_size
+
+        # Create a MaskedOlmoEarthSample wrapping the input as the specified modality.
+        # OlmoEarth expects input shape: (B, H_patches, W_patches, T, BandSets, C_per_bandset, patch_size, patch_size)
+        # For single-timestep, single-band-set usage:
+        # Reshape input: (B, C, H, W) -> (B, h_patches, w_patches, 1, 1, C, patch_size, patch_size)
+        x_patchified = x.unfold(2, self.patch_size, self.patch_size).unfold(
+            3, self.patch_size, self.patch_size
+        )
+        # x_patchified: (B, C, h_patches, w_patches, patch_size, patch_size)
+        x_patchified = x_patchified.permute(0, 2, 3, 1, 4, 5)
+        # x_patchified: (B, h_patches, w_patches, C, patch_size, patch_size)
+        x_patchified = x_patchified.unsqueeze(3).unsqueeze(4)
+        # x_patchified: (B, h_patches, w_patches, 1, 1, C, patch_size, patch_size)
+
+        # Create mask: all tokens are visible (ONLINE_ENCODER value)
+        mask = torch.full(
+            (B, h_patches, w_patches, 1, 1),
+            fill_value=MaskValue.ONLINE_ENCODER.value,
+            device=x.device,
+            dtype=torch.long,
+        )
+
+        # Construct timestamps (single timestep, zeros)
+        timestamps = torch.zeros(B, 1, device=x.device, dtype=torch.float32)
+
+        # Build the sample
+        sample_dict = {
+            self.modality: x_patchified,
+            f"{self.modality}_mask": mask,
+        }
+        sample = MaskedOlmoEarthSample(
+            timestamps=timestamps,
+            **sample_dict,
+        )
+
+        # Run encoder
+        encoder_output = self.encoder(
+            sample,
+            patch_size=self.patch_size,
+            input_res=self.input_res,
+        )
+
+        # Extract the projected/aggregated embeddings
+        # The encoder returns a dict with 'project_aggregated' containing per-patch embeddings
+        # Shape: (B, h_patches, w_patches, embed_dim)
+        proj_agg = encoder_output["project_aggregated"]
+
+        # proj_agg is a Tensor of shape (B, h_patches * w_patches, embed_dim)
+        # or it may come from TokensAndMasks - extract the modality tokens
+        if hasattr(proj_agg, "as_tensor"):
+            features = proj_agg.as_tensor()
+        elif isinstance(proj_agg, dict):
+            # Get the first available modality
+            features = next(iter(proj_agg.values()))
+            if features.ndim > 3:
+                features = features.flatten(1, -2)
+        elif isinstance(proj_agg, Tensor):
+            features = proj_agg
+        else:
+            # Fallback: try to get tokens from tokens_and_masks
+            tokens_and_masks = encoder_output["tokens_and_masks"]
+            modality_tokens = getattr(tokens_and_masks, self.modality, None)
+            if modality_tokens is not None:
+                # Shape: (B, h, w, t, bs, D) -> flatten spatial
+                features = modality_tokens.flatten(1, -2)
+            else:
+                msg = f"Could not extract features from OlmoEarth encoder output: {type(proj_agg)}"
+                raise RuntimeError(msg)
+
+        # Reshape from (B, N, D) to (B, D, H', W')
+        if features.ndim == 3:
+            features = features[:, : h_patches * w_patches, :]
+            features = features.permute(0, 2, 1).reshape(B, self.embed_dim, h_patches, w_patches)
+        elif features.ndim == 4:
+            # Already (B, H', W', D) format
+            features = features.permute(0, 3, 1, 2)
+
+        return [features]
+
+
+def _create_olmoearth_backbone(
+    variant: str,
+    pretrained: bool = True,
+    patch_size: int = 8,
+    input_res: int = 10,
+    modality: str = "sentinel2",
+    ckpt_path: str | None = None,
+    **kwargs,
+) -> OlmoEarthBackbone:
+    """Create an OlmoEarth backbone model.
+
+    Args:
+        variant: Model variant name (e.g. "olmoearth_v1_base")
+        pretrained: Whether to load pretrained weights
+        patch_size: Patch size for tokenization
+        input_res: Input resolution in meters
+        modality: Input modality name
+        ckpt_path: Optional path to local checkpoint
+        **kwargs: Additional keyword arguments (unused)
+
+    Returns:
+        OlmoEarthBackbone instance
+    """
+    if variant not in OLMOEARTH_CONFIGS:
+        msg = f"Unknown OlmoEarth variant '{variant}'. Available: {list(OLMOEARTH_CONFIGS.keys())}"
+        raise ValueError(msg)
+
+    cfg = OLMOEARTH_CONFIGS[variant]
+
+    model = OlmoEarthBackbone(
+        model_id=cfg["model_id"],
+        embed_dim=cfg["embed_dim"],
+        pretrained=pretrained,
+        patch_size=patch_size,
+        input_res=input_res,
+        modality=modality,
+        ckpt_path=ckpt_path,
+    )
+
+    return model
+
+
+# Register all OlmoEarth variants with the TerraTorch backbone registry
+
+
+@TERRATORCH_BACKBONE_REGISTRY.register
+def olmoearth_v1_nano(pretrained: bool = True, **kwargs) -> OlmoEarthBackbone:
+    """OlmoEarth v1 Nano (1.4M encoder params)."""
+    return _create_olmoearth_backbone("olmoearth_v1_nano", pretrained=pretrained, **kwargs)
+
+
+@TERRATORCH_BACKBONE_REGISTRY.register
+def olmoearth_v1_tiny(pretrained: bool = True, **kwargs) -> OlmoEarthBackbone:
+    """OlmoEarth v1 Tiny (6.2M encoder params)."""
+    return _create_olmoearth_backbone("olmoearth_v1_tiny", pretrained=pretrained, **kwargs)
+
+
+@TERRATORCH_BACKBONE_REGISTRY.register
+def olmoearth_v1_base(pretrained: bool = True, **kwargs) -> OlmoEarthBackbone:
+    """OlmoEarth v1 Base (89M encoder params)."""
+    return _create_olmoearth_backbone("olmoearth_v1_base", pretrained=pretrained, **kwargs)
+
+
+@TERRATORCH_BACKBONE_REGISTRY.register
+def olmoearth_v1_large(pretrained: bool = True, **kwargs) -> OlmoEarthBackbone:
+    """OlmoEarth v1 Large (308M encoder params)."""
+    return _create_olmoearth_backbone("olmoearth_v1_large", pretrained=pretrained, **kwargs)
+
+
+@TERRATORCH_BACKBONE_REGISTRY.register
+def olmoearth_v1_1_nano(pretrained: bool = True, **kwargs) -> OlmoEarthBackbone:
+    """OlmoEarth v1.1 Nano (5.5M encoder params)."""
+    return _create_olmoearth_backbone("olmoearth_v1_1_nano", pretrained=pretrained, **kwargs)
+
+
+@TERRATORCH_BACKBONE_REGISTRY.register
+def olmoearth_v1_1_tiny(pretrained: bool = True, **kwargs) -> OlmoEarthBackbone:
+    """OlmoEarth v1.1 Tiny (12.5M encoder params)."""
+    return _create_olmoearth_backbone("olmoearth_v1_1_tiny", pretrained=pretrained, **kwargs)
+
+
+@TERRATORCH_BACKBONE_REGISTRY.register
+def olmoearth_v1_1_base(pretrained: bool = True, **kwargs) -> OlmoEarthBackbone:
+    """OlmoEarth v1.1 Base (114M encoder params)."""
+    return _create_olmoearth_backbone("olmoearth_v1_1_base", pretrained=pretrained, **kwargs)
+
+
+@TERRATORCH_BACKBONE_REGISTRY.register
+def olmoearth_v1_2_nano(pretrained: bool = True, **kwargs) -> OlmoEarthBackbone:
+    """OlmoEarth v1.2 Nano (5.5M encoder params)."""
+    return _create_olmoearth_backbone("olmoearth_v1_2_nano", pretrained=pretrained, **kwargs)
+
+
+@TERRATORCH_BACKBONE_REGISTRY.register
+def olmoearth_v1_2_tiny(pretrained: bool = True, **kwargs) -> OlmoEarthBackbone:
+    """OlmoEarth v1.2 Tiny (12.5M encoder params)."""
+    return _create_olmoearth_backbone("olmoearth_v1_2_tiny", pretrained=pretrained, **kwargs)
+
+
+@TERRATORCH_BACKBONE_REGISTRY.register
+def olmoearth_v1_2_small(pretrained: bool = True, **kwargs) -> OlmoEarthBackbone:
+    """OlmoEarth v1.2 Small (35.6M encoder params)."""
+    return _create_olmoearth_backbone("olmoearth_v1_2_small", pretrained=pretrained, **kwargs)
+
+
+@TERRATORCH_BACKBONE_REGISTRY.register
+def olmoearth_v1_2_base(pretrained: bool = True, **kwargs) -> OlmoEarthBackbone:
+    """OlmoEarth v1.2 Base (114M encoder params)."""
+    return _create_olmoearth_backbone("olmoearth_v1_2_base", pretrained=pretrained, **kwargs)

--- a/terratorch/models/backbones/olmoearth.py
+++ b/terratorch/models/backbones/olmoearth.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 OLMOEARTH_CONFIGS: dict[str, dict] = {
     "olmoearth_v1_nano": {
         "model_id": "OlmoEarth-v1-Nano",
-        "embed_dim": 64,
+        "embed_dim": 128,
     },
     "olmoearth_v1_tiny": {
         "model_id": "OlmoEarth-v1-Tiny",
@@ -81,12 +81,13 @@ class OlmoEarthBackbone(nn.Module):
 
     This wrapper loads an OlmoEarth model (encoder only) and adapts its
     forward pass to produce a list of feature maps compatible with TerraTorch
-    decoders. The encoder's output embeddings are reshaped from (B, N, D) token
-    sequences to (B, D, H, W) spatial feature maps.
+    decoders. The encoder outputs per-patch token embeddings which are reshaped
+    into (B, D, H', W') spatial feature maps.
 
     OlmoEarth's native interface expects a MaskedOlmoEarthSample input with
-    multi-modal data. This wrapper provides a simplified interface that accepts
-    a standard image tensor (B, C, H, W) and wraps it as Sentinel-2 input.
+    multi-modal data in [B, H, W, T, C] format. This wrapper provides a
+    simplified interface that accepts a standard image tensor (B, C, H, W) and
+    wraps it as Sentinel-2 L2A input.
     """
 
     def __init__(
@@ -96,7 +97,7 @@ class OlmoEarthBackbone(nn.Module):
         pretrained: bool = True,
         patch_size: int = 8,
         input_res: int = 10,
-        modality: str = "sentinel2",
+        modality: str = "sentinel2_l2a",
         ckpt_path: str | None = None,
     ):
         """Initialize OlmoEarth backbone.
@@ -107,14 +108,15 @@ class OlmoEarthBackbone(nn.Module):
             pretrained: Whether to load pretrained weights from HuggingFace
             patch_size: Patch size for tokenization (default 8)
             input_res: Input resolution in meters (default 10m for Sentinel-2)
-            modality: Input modality name (default "sentinel2")
+            modality: Input modality name matching MaskedOlmoEarthSample fields
+                (default "sentinel2_l2a")
             ckpt_path: Optional path to a local checkpoint file
         """
         super().__init__()
 
+        from olmoearth_pretrain.data.constants import Modality as ModalitySpec
         from olmoearth_pretrain.model_loader import ModelID, load_model_from_id, load_model_from_path
 
-        self.embed_dim = embed_dim
         self.patch_size = patch_size
         self.input_res = input_res
         self.modality = modality
@@ -129,8 +131,15 @@ class OlmoEarthBackbone(nn.Module):
         # Extract only the encoder
         self.encoder = full_model.encoder
 
+        # Use the encoder's actual embedding size as the authoritative embed_dim
+        self.embed_dim = self.encoder.embedding_size
+
+        # Determine number of band sets for this modality (needed for mask shape)
+        modality_spec = ModalitySpec.get(self.modality)
+        self.num_band_sets = len(modality_spec.band_sets)
+
         # Expose embedding dimension for downstream components
-        self.num_features = embed_dim
+        self.num_features = self.embed_dim
 
     @property
     def out_channels(self) -> list[int]:
@@ -161,39 +170,29 @@ class OlmoEarthBackbone(nn.Module):
         h_patches = H // self.patch_size
         w_patches = W // self.patch_size
 
-        # Create a MaskedOlmoEarthSample wrapping the input as the specified modality.
-        # OlmoEarth expects input shape: (B, H_patches, W_patches, T, BandSets, C_per_bandset, patch_size, patch_size)
-        # For single-timestep, single-band-set usage:
-        # Reshape input: (B, C, H, W) -> (B, h_patches, w_patches, 1, 1, C, patch_size, patch_size)
-        x_patchified = x.unfold(2, self.patch_size, self.patch_size).unfold(
-            3, self.patch_size, self.patch_size
-        )
-        # x_patchified: (B, C, h_patches, w_patches, patch_size, patch_size)
-        x_patchified = x_patchified.permute(0, 2, 3, 1, 4, 5)
-        # x_patchified: (B, h_patches, w_patches, C, patch_size, patch_size)
-        x_patchified = x_patchified.unsqueeze(3).unsqueeze(4)
-        # x_patchified: (B, h_patches, w_patches, 1, 1, C, patch_size, patch_size)
+        # OlmoEarth expects raw pixel data in [B, H, W, T, C] format.
+        # Reshape from (B, C, H, W) -> (B, H, W, T=1, C)
+        x_bhwtc = x.permute(0, 2, 3, 1).unsqueeze(3)  # (B, H, W, 1, C)
 
-        # Create mask: all tokens are visible (ONLINE_ENCODER value)
+        # Create mask at pixel resolution: [B, H, W, T, num_band_sets]
+        # All tokens visible (ONLINE_ENCODER)
         mask = torch.full(
-            (B, h_patches, w_patches, 1, 1),
+            (B, H, W, 1, self.num_band_sets),
             fill_value=MaskValue.ONLINE_ENCODER.value,
             device=x.device,
             dtype=torch.long,
         )
 
-        # Construct timestamps (single timestep, zeros)
-        timestamps = torch.zeros(B, 1, device=x.device, dtype=torch.float32)
+        # Construct timestamps: [B, T, 3] with [day, month, year] as long
+        timestamps = torch.zeros(B, 1, 3, device=x.device, dtype=torch.long)
 
-        # Build the sample
-        sample_dict = {
-            self.modality: x_patchified,
+        # Build the MaskedOlmoEarthSample with the correct field names
+        sample_kwargs = {
+            "timestamps": timestamps,
+            self.modality: x_bhwtc,
             f"{self.modality}_mask": mask,
         }
-        sample = MaskedOlmoEarthSample(
-            timestamps=timestamps,
-            **sample_dict,
-        )
+        sample = MaskedOlmoEarthSample(**sample_kwargs)
 
         # Run encoder
         encoder_output = self.encoder(
@@ -202,40 +201,16 @@ class OlmoEarthBackbone(nn.Module):
             input_res=self.input_res,
         )
 
-        # Extract the projected/aggregated embeddings
-        # The encoder returns a dict with 'project_aggregated' containing per-patch embeddings
-        # Shape: (B, h_patches, w_patches, embed_dim)
-        proj_agg = encoder_output["project_aggregated"]
+        # Extract spatial token embeddings from tokens_and_masks.
+        # Shape: (B, H_patches, W_patches, T, band_sets, D)
+        tokens_and_masks = encoder_output["tokens_and_masks"]
+        modality_tokens = getattr(tokens_and_masks, self.modality)
 
-        # proj_agg is a Tensor of shape (B, h_patches * w_patches, embed_dim)
-        # or it may come from TokensAndMasks - extract the modality tokens
-        if hasattr(proj_agg, "as_tensor"):
-            features = proj_agg.as_tensor()
-        elif isinstance(proj_agg, dict):
-            # Get the first available modality
-            features = next(iter(proj_agg.values()))
-            if features.ndim > 3:
-                features = features.flatten(1, -2)
-        elif isinstance(proj_agg, Tensor):
-            features = proj_agg
-        else:
-            # Fallback: try to get tokens from tokens_and_masks
-            tokens_and_masks = encoder_output["tokens_and_masks"]
-            modality_tokens = getattr(tokens_and_masks, self.modality, None)
-            if modality_tokens is not None:
-                # Shape: (B, h, w, t, bs, D) -> flatten spatial
-                features = modality_tokens.flatten(1, -2)
-            else:
-                msg = f"Could not extract features from OlmoEarth encoder output: {type(proj_agg)}"
-                raise RuntimeError(msg)
+        # Average over T and band_sets dims to get (B, H', W', D)
+        features = modality_tokens.mean(dim=(3, 4))
 
-        # Reshape from (B, N, D) to (B, D, H', W')
-        if features.ndim == 3:
-            features = features[:, : h_patches * w_patches, :]
-            features = features.permute(0, 2, 1).reshape(B, self.embed_dim, h_patches, w_patches)
-        elif features.ndim == 4:
-            # Already (B, H', W', D) format
-            features = features.permute(0, 3, 1, 2)
+        # Reshape to (B, D, H', W') for compatibility with TerraTorch decoders
+        features = features.permute(0, 3, 1, 2)
 
         return [features]
 
@@ -245,7 +220,7 @@ def _create_olmoearth_backbone(
     pretrained: bool = True,
     patch_size: int = 8,
     input_res: int = 10,
-    modality: str = "sentinel2",
+    modality: str = "sentinel2_l2a",
     ckpt_path: str | None = None,
     **kwargs,
 ) -> OlmoEarthBackbone:

--- a/terratorch/models/timm_model_factory.py
+++ b/terratorch/models/timm_model_factory.py
@@ -9,8 +9,12 @@ import os
 from timm import create_model
 from torch import nn
 from torchgeo.models import get_weight
-from torchgeo.trainers import utils
 from torchvision.models._api import WeightsEnum
+
+try:
+    from torchgeo.trainers import utils as _torchgeo_utils
+except ImportError:
+    _torchgeo_utils = None
 
 from terratorch.models.model import Model, ModelFactory, ModelOutput
 from terratorch.models.utils import extract_prefix_keys
@@ -58,10 +62,19 @@ class TimmModelFactory(ModelFactory):
                 state_dict = weights.get_state_dict(progress=True)
             except ValueError:
                 if os.path.exists(pretrained):
-                    _, state_dict = utils.extract_backbone(pretrained)
+                    if _torchgeo_utils is None:
+                        msg = (
+                            "Loading weights from checkpoint requires torchgeo<0.6. "
+                            "Please install a compatible version or provide weights as a WeightsEnum."
+                        )
+                        raise ImportError(msg)
+                    _, state_dict = _torchgeo_utils.extract_backbone(pretrained)
                 else:
                     state_dict = get_weight(pretrained).get_state_dict(progress=True)
-            model = utils.load_state_dict(model, state_dict)
+            if _torchgeo_utils is not None:
+                model = _torchgeo_utils.load_state_dict(model, state_dict)
+            else:
+                model.load_state_dict(state_dict, strict=False)
 
         return TimmModelWrapper(model)
 

--- a/tests/test_olmoearth.py
+++ b/tests/test_olmoearth.py
@@ -77,12 +77,12 @@ class TestOlmoEarthBackbone:
 
         model = OlmoEarthBackbone(
             model_id="OlmoEarth-v1-Nano",
-            embed_dim=64,
+            embed_dim=128,
             pretrained=False,
         )
         assert model is not None
-        assert model.embed_dim == 64
-        assert model.out_channels == [64]
+        assert model.embed_dim == 128
+        assert model.out_channels == [128]
         gc.collect()
 
     @skip_no_olmoearth
@@ -92,7 +92,7 @@ class TestOlmoEarthBackbone:
 
         model = OlmoEarthBackbone(
             model_id="OlmoEarth-v1-Nano",
-            embed_dim=64,
+            embed_dim=128,
             pretrained=False,
             patch_size=8,
         )
@@ -104,7 +104,7 @@ class TestOlmoEarthBackbone:
         assert isinstance(outputs, list)
         assert len(outputs) == 1
         # With patch_size=8 and input 64x64, expect 8x8 spatial output
-        assert outputs[0].shape == (1, 64, 8, 8)
+        assert outputs[0].shape == (1, 128, 8, 8)
         gc.collect()
 
     @skip_no_olmoearth
@@ -114,7 +114,7 @@ class TestOlmoEarthBackbone:
 
         model = OlmoEarthBackbone(
             model_id="OlmoEarth-v1-Nano",
-            embed_dim=64,
+            embed_dim=128,
             pretrained=False,
             patch_size=8,
         )
@@ -124,7 +124,7 @@ class TestOlmoEarthBackbone:
             outputs = model(x)
             expected_h = h // 8
             expected_w = w // 8
-            assert outputs[0].shape == (1, 64, expected_h, expected_w), (
+            assert outputs[0].shape == (1, 128, expected_h, expected_w), (
                 f"Wrong shape for input ({h}, {w})"
             )
         gc.collect()
@@ -136,7 +136,7 @@ class TestOlmoEarthBackbone:
 
         model = TERRATORCH_BACKBONE_REGISTRY.build("olmoearth_v1_nano", pretrained=False)
         assert model is not None
-        assert model.embed_dim == 64
+        assert model.embed_dim == 128
         gc.collect()
 
     @skip_no_olmoearth

--- a/tests/test_olmoearth.py
+++ b/tests/test_olmoearth.py
@@ -1,0 +1,158 @@
+# Copyright contributors to the Terratorch project
+# Licensed under the Apache License 2.0
+
+"""Tests for OlmoEarth backbone integration.
+
+These tests verify that the OlmoEarth backbone can be registered,
+instantiated, and produce the expected output shapes. Tests that require
+the olmoearth-pretrain package are skipped if the package is not installed.
+"""
+
+import gc
+
+import pytest
+import torch
+
+# Check if olmoearth-pretrain is available
+try:
+    import olmoearth_pretrain  # noqa: F401
+
+    HAS_OLMOEARTH = True
+except ImportError:
+    HAS_OLMOEARTH = False
+
+skip_no_olmoearth = pytest.mark.skipif(
+    not HAS_OLMOEARTH,
+    reason="olmoearth-pretrain not installed",
+)
+
+
+class TestOlmoEarthRegistration:
+    """Test that OlmoEarth models are properly registered."""
+
+    @skip_no_olmoearth
+    def test_olmoearth_models_in_registry(self):
+        """Verify all OlmoEarth variants are in the backbone registry."""
+        from terratorch.registry import TERRATORCH_BACKBONE_REGISTRY
+
+        expected_models = [
+            "olmoearth_v1_nano",
+            "olmoearth_v1_tiny",
+            "olmoearth_v1_base",
+            "olmoearth_v1_large",
+            "olmoearth_v1_1_nano",
+            "olmoearth_v1_1_tiny",
+            "olmoearth_v1_1_base",
+            "olmoearth_v1_2_nano",
+            "olmoearth_v1_2_tiny",
+            "olmoearth_v1_2_small",
+            "olmoearth_v1_2_base",
+        ]
+
+        for model_name in expected_models:
+            assert model_name in TERRATORCH_BACKBONE_REGISTRY, (
+                f"{model_name} not found in TERRATORCH_BACKBONE_REGISTRY"
+            )
+
+    @skip_no_olmoearth
+    def test_olmoearth_config_keys(self):
+        """Verify config structure for all registered variants."""
+        from terratorch.models.backbones.olmoearth import OLMOEARTH_CONFIGS
+
+        for name, cfg in OLMOEARTH_CONFIGS.items():
+            assert "model_id" in cfg, f"Missing model_id in config for {name}"
+            assert "embed_dim" in cfg, f"Missing embed_dim in config for {name}"
+            assert isinstance(cfg["embed_dim"], int), (
+                f"embed_dim should be int for {name}"
+            )
+
+
+class TestOlmoEarthBackbone:
+    """Test OlmoEarth backbone instantiation and forward pass."""
+
+    @skip_no_olmoearth
+    def test_create_backbone_no_weights(self):
+        """Test creating an OlmoEarth backbone without pretrained weights."""
+        from terratorch.models.backbones.olmoearth import OlmoEarthBackbone
+
+        model = OlmoEarthBackbone(
+            model_id="OlmoEarth-v1-Nano",
+            embed_dim=64,
+            pretrained=False,
+        )
+        assert model is not None
+        assert model.embed_dim == 64
+        assert model.out_channels == [64]
+        gc.collect()
+
+    @skip_no_olmoearth
+    def test_backbone_forward_shape(self):
+        """Test that forward pass produces correct output shape."""
+        from terratorch.models.backbones.olmoearth import OlmoEarthBackbone
+
+        model = OlmoEarthBackbone(
+            model_id="OlmoEarth-v1-Nano",
+            embed_dim=64,
+            pretrained=False,
+            patch_size=8,
+        )
+
+        # Input: batch=1, channels=12 (Sentinel-2), H=64, W=64
+        x = torch.randn(1, 12, 64, 64)
+        outputs = model(x)
+
+        assert isinstance(outputs, list)
+        assert len(outputs) == 1
+        # With patch_size=8 and input 64x64, expect 8x8 spatial output
+        assert outputs[0].shape == (1, 64, 8, 8)
+        gc.collect()
+
+    @skip_no_olmoearth
+    def test_backbone_forward_different_input_sizes(self):
+        """Test forward pass with different input sizes."""
+        from terratorch.models.backbones.olmoearth import OlmoEarthBackbone
+
+        model = OlmoEarthBackbone(
+            model_id="OlmoEarth-v1-Nano",
+            embed_dim=64,
+            pretrained=False,
+            patch_size=8,
+        )
+
+        for h, w in [(64, 64), (128, 128), (96, 96)]:
+            x = torch.randn(1, 12, h, w)
+            outputs = model(x)
+            expected_h = h // 8
+            expected_w = w // 8
+            assert outputs[0].shape == (1, 64, expected_h, expected_w), (
+                f"Wrong shape for input ({h}, {w})"
+            )
+        gc.collect()
+
+    @skip_no_olmoearth
+    def test_backbone_via_registry(self):
+        """Test creating backbone via the registry function."""
+        from terratorch.registry import TERRATORCH_BACKBONE_REGISTRY
+
+        model = TERRATORCH_BACKBONE_REGISTRY.build("olmoearth_v1_nano", pretrained=False)
+        assert model is not None
+        assert model.embed_dim == 64
+        gc.collect()
+
+    @skip_no_olmoearth
+    def test_invalid_variant_raises(self):
+        """Test that an invalid variant name raises ValueError."""
+        from terratorch.models.backbones.olmoearth import _create_olmoearth_backbone
+
+        with pytest.raises(ValueError, match="Unknown OlmoEarth variant"):
+            _create_olmoearth_backbone("olmoearth_v99_mega", pretrained=False)
+
+
+class TestOlmoEarthImportGuard:
+    """Test behavior when olmoearth-pretrain is not installed."""
+
+    def test_import_does_not_fail_without_package(self):
+        """The __init__.py import should not fail even without olmoearth-pretrain."""
+        # This test always passes because __init__.py uses try/except
+        # If import failed, the entire test suite would fail to collect
+        pass


### PR DESCRIPTION
## Summary

Fixes the OlmoEarth backbone integration to work correctly with the `olmoearth-pretrain` package API.

## Changes

- **Modality name**: Use `sentinel2_l2a` (matching `MaskedOlmoEarthSample` NamedTuple fields) instead of the invalid `sentinel2`
- **Input format**: Pass raw pixels in `[B, H, W, T, C]` format — the encoder handles patchification internally
- **Mask format**: Use pixel-resolution mask `[B, H, W, T, num_band_sets]` with correct band set count (3 for S2 L2A)
- **Timestamps**: Use `[B, T, 3]` long tensors with `[day, month, year]` (not float zeros)
- **Embed dim**: Read from `encoder.embedding_size` at runtime instead of relying on potentially stale config values
- **Feature extraction**: Use per-modality spatial tokens from `tokens_and_masks` (averaged over T and band_sets), not the global `project_aggregated` vector
- **Config fix**: Corrected Nano embed_dim from 64 → 128

## Testing

All 8 tests in `tests/test_olmoearth.py` pass (~2 min on CPU, no GPU required):
- Registration tests (2)
- Instantiation without weights (1)
- Forward pass shape verification (1)
- Multiple input sizes (1)
- Registry-based creation (1)
- Invalid variant error (1)
- Import guard (1)