### PR TITLE
feat: add pluggable source sink api for out of core inference

### DIFF
--- a/terratorch/tasks/tiled_inference.py
+++ b/terratorch/tasks/tiled_inference.py
@@ -3,12 +3,35 @@ This does some additional things over the obvious fold -> predict -> unfold logi
 e.g. cropping out areas around model prediction to reduce artifacts
 
 It additionally rebatches after the fold operation to gain speed up.
+
+Source / Sink API
+-----------------
+The :func:`tiled_inference` function accepts optional *source* and *sink* objects that
+decouple **reading** and **writing** from the in-memory tensor path.
+
+* A **source** is any callable that matches :class:`TileSource`.  Given an
+  :class:`InferenceInput` descriptor it should return the chip tensor
+  ``(C, H, W)`` – or ``(C, T, H, W)`` for multi-temporal inputs – on the CPU.
+  This lets callers read from disk (e.g. a rasterio window) instead of holding
+  the whole image in memory.
+
+* A **sink** is an object that matches :class:`TileSink`.  Its
+  :meth:`~TileSink.write` method is called for every predicted chip, and its
+  :meth:`~TileSink.finalize` method is called once at the end to produce (or
+  flush) the final result.  This lets callers write directly to a file and
+  avoid building the full output tensor.
+
+Both are optional.  When omitted the function behaves exactly as before:
+``input_batch`` is used as the in-memory source and all predicted chips are
+accumulated in RAM before being averaged and returned.
 """
 
 import math
 import warnings
+from abc import abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
 
 import torch
 import tqdm
@@ -32,6 +55,247 @@ class TiledInferenceParameters:
     blend_overlaps: bool = (True,)
     batch_size: int = (16,)
     verbose: bool = (False,)
+
+
+# ---------------------------------------------------------------------------
+# Source / Sink protocols
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class TileSource(Protocol):
+    """Protocol for objects that supply chip tensors on demand.
+
+    Implement this to read tiles lazily (e.g. from a file or a remote store)
+    instead of keeping the whole image in memory.
+
+    Example::
+
+        class RasterioSource:
+            def __init__(self, path: str):
+                import rasterio
+                self._ds = rasterio.open(path)
+
+            def __call__(self, tile: InferenceInput) -> torch.Tensor:
+                row_off = tile.input_coords[0].start
+                col_off = tile.input_coords[1].start
+                h = tile.input_coords[0].stop - row_off
+                w = tile.input_coords[1].stop - col_off
+                window = rasterio.windows.Window(col_off, row_off, w, h)
+                data = self._ds.read(window=window)        # (C, H, W)
+                return torch.from_numpy(data).float()
+    """
+
+    @abstractmethod
+    def __call__(self, tile: "InferenceInput") -> torch.Tensor:
+        """Return the chip tensor (CPU) for *tile*.
+
+        Args:
+            tile: Descriptor produced by :func:`get_input_chips` that carries
+                the destination coordinates and blend mask for this chip.
+                The caller has already sliced ``input_data`` on ``tile`` when
+                using the default in-memory path; a custom source may ignore
+                ``tile.input_data`` and read the raw window from wherever it
+                likes.
+
+        Returns:
+            torch.Tensor: A CPU tensor of shape ``(C, H, W)`` or
+            ``(C, T, H, W)``.  It will be stacked with other chips and moved
+            to the inference device by the caller.
+        """
+        ...
+
+
+@runtime_checkable
+class TileSink(Protocol):
+    """Protocol for objects that consume predicted chip tensors one at a time.
+
+    Implement this to stream predictions directly to disk or another consumer
+    instead of accumulating them in a large in-memory tensor.
+
+    The lifecycle is::
+
+        for chip, prediction in ...:
+            sink.write(chip, prediction)
+        result = sink.finalize()
+
+    Example – write to a file::
+
+        class RasterioSink:
+            def __init__(self, path, profile, h_img, w_img, n_classes):
+                import rasterio
+                self._acc  = torch.zeros(1, n_classes, h_img, w_img)
+                self._cnt  = torch.zeros(1, h_img, w_img)
+                self._path = path
+                self._profile = profile
+
+            def write(self, tile: InferenceInput, prediction: torch.Tensor) -> None:
+                if tile.output_crop is not None:
+                    prediction = prediction[...,
+                                            tile.output_crop[0],
+                                            tile.output_crop[1]]
+                self._acc[tile.batch, :,
+                          tile.input_coords[0],
+                          tile.input_coords[1]] += prediction * tile.blend_mask
+                self._cnt[tile.batch,
+                          tile.input_coords[0],
+                          tile.input_coords[1]] += tile.blend_mask
+
+            def finalize(self):
+                result = self._acc / self._cnt.unsqueeze(1)
+                import rasterio
+                with rasterio.open(self._path, "w", **self._profile) as dst:
+                    dst.write(result[0].numpy())
+                return result
+    """
+
+    @abstractmethod
+    def write(self, tile: "InferenceInput", prediction: torch.Tensor) -> None:
+        """Accept one predicted chip.
+
+        ``prediction`` is a CPU tensor already transferred from the inference
+        device.  ``tile`` provides the destination coordinates and blend mask.
+        The sink is responsible for any blending / averaging it wants to apply.
+
+        Args:
+            tile: The :class:`InferenceInput` descriptor for this chip.
+            prediction: CPU tensor of shape ``(C, H, W)`` (one sample from the
+                batch dimension has already been indexed by the caller).
+        """
+        ...
+
+    @abstractmethod
+    def finalize(self) -> "torch.Tensor | None":
+        """Called once after all chips have been written.
+
+        Returns:
+            The final output tensor, or ``None`` if the sink writes to an
+            external store (file, database, …) and the caller does not need an
+            in-memory result.
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Default (in-memory) source / sink implementations
+# ---------------------------------------------------------------------------
+
+
+class InMemoryTileSource:
+    """Default :class:`TileSource` backed by a pre-loaded tensor.
+
+    This is the source used internally by :func:`tiled_inference` when no
+    custom source is supplied.  It simply returns the ``input_data`` that was
+    already sliced and stored on the :class:`InferenceInput` descriptor.
+    """
+
+    def __call__(self, tile: "InferenceInput") -> torch.Tensor:
+        return tile.input_data
+
+
+class InMemoryTileSink:
+    """Default :class:`TileSink` that accumulates all chips into a single tensor.
+
+    This reproduces the original behaviour of :func:`tiled_inference`:
+
+    * chips are weighted by their blend mask and summed,
+    * :meth:`finalize` divides by the accumulated blend weights (or just
+      returns the last-written value when ``average_patches=False``),
+    * padding is stripped and the tensor is transferred to ``device``.
+
+    Args:
+        input_batch_size: Number of images in the batch.
+        h_img: Height of the output canvas *before* padding removal.
+        w_img: Width of the output canvas *before* padding removal.
+        delta: Border width used for padding; set to 0 when ``padding`` is
+            ``False``.
+        device: Device to which the final tensor is moved.
+        padding: The padding mode that was used (or ``False``).
+        average_patches: If ``True``, overlapping areas are averaged using
+            the blend mask.  If ``False``, later chips overwrite earlier ones.
+    """
+
+    def __init__(
+        self,
+        input_batch_size: int,
+        h_img: int,
+        w_img: int,
+        delta: int,
+        device: "str | torch.device",
+        padding: "str | bool",
+        average_patches: bool,
+    ) -> None:
+        self._input_batch_size = input_batch_size
+        self._h_img = h_img
+        self._w_img = w_img
+        self._delta = delta
+        self._device = device
+        self._padding = padding
+        self._average_patches = average_patches
+
+        # Lazily allocated once we see the first prediction.
+        self._preds: torch.Tensor | None = None
+        self._preds_count: torch.Tensor | None = None
+
+    def _init_accumulators(self, out_channels: int) -> None:
+        if self._padding:
+            h = self._h_img + 2 * self._delta
+            w = self._w_img + 2 * self._delta
+        else:
+            h, w = self._h_img, self._w_img
+        self._preds = torch.zeros((self._input_batch_size, out_channels, h, w))
+        self._preds_count = torch.zeros(self._input_batch_size, h, w)
+
+    def write(self, tile: "InferenceInput", prediction: torch.Tensor) -> None:
+        if self._preds is None:
+            out_channels = 1 if len(prediction.shape) == 2 else prediction.shape[0]
+            self._init_accumulators(out_channels)
+
+        if tile.output_crop is not None:
+            prediction = prediction[..., tile.output_crop[0], tile.output_crop[1]]
+
+        if self._average_patches:
+            self._preds[
+                tile.batch,
+                :,
+                tile.input_coords[0],
+                tile.input_coords[1],
+            ] += prediction * tile.blend_mask
+        else:
+            self._preds[
+                tile.batch,
+                :,
+                tile.input_coords[0],
+                tile.input_coords[1],
+            ] = prediction
+
+        self._preds_count[
+            tile.batch,
+            tile.input_coords[0],
+            tile.input_coords[1],
+        ] += tile.blend_mask
+
+    def finalize(self) -> torch.Tensor:
+        if self._preds is None:
+            raise RuntimeError("No chips were written to InMemoryTileSink.")
+
+        preds = self._preds
+        preds_count = self._preds_count
+
+        if self._padding:
+            d = self._delta
+            preds = preds[..., d:-d, d:-d]
+            preds_count = preds_count[..., d:-d, d:-d]
+
+        if (preds_count == 0).sum() != 0:
+            msg = "Some pixels did not receive a classification!"
+            raise RuntimeError(msg)
+
+        output = preds
+        if self._average_patches:
+            output = output / preds_count.unsqueeze(1)
+
+        return output.to(self._device)
 
 
 def get_blend_mask(
@@ -359,7 +623,7 @@ def generate_tiled_inference_output(
 
 def tiled_inference(
     model_forward: Callable,
-    input_batch: torch.Tensor,
+    input_batch: "torch.Tensor | dict | None" = None,
     out_channels: int | None = None,
     inference_parameters: TiledInferenceParameters | None = None,
     crop: int = 224,
@@ -373,21 +637,25 @@ def tiled_inference(
     blend_overlaps: bool = True,
     batch_size: int = 16,
     verbose: bool = False,
-    padding: str | bool = "reflect",
+    padding: "str | bool" = "reflect",
     device: str | None = None,
+    source: "TileSource | None" = None,
+    sink: "TileSink | None" = None,
     **kwargs,
-) -> torch.Tensor:
+) -> "torch.Tensor | None":
     """
     Divide an image into (potentially) overlapping chips and perform inference on them.
-    Additionally, re-batch for varibale GPU utilization defined by crop size and batch_size.
+    Additionally, re-batch for variable GPU utilization defined by crop size and batch_size.
     The overlap between chips is defined with: crop - stride - 2 * delta.
 
     Args:
-        model_forward (Callable): Callable that return the output of the model.
-        input_batch (torch.Tensor): Input batch to be processed
-        out_channels (int): Number of output channels
+        model_forward (Callable): Callable that returns the output of the model.
+        input_batch (torch.Tensor | dict | None): Input batch to be processed.
+            May be ``None`` when a custom *source* is provided that does not
+            need a pre-loaded tensor.
+        out_channels (int): Number of output channels. Deprecated.
         inference_parameters (TiledInferenceParameters): Parameters to be used for inference.
-            Deprecated, please us directly pass the parameters to tiled_inference.
+            Deprecated, please pass the parameters directly to tiled_inference.
         crop (int): height and width of the smaller chips. Ignored if h_crop or w_crop is provided. Defaults to 224.
         stride (int): size of the stride. Ignored if h_stride or w_stride is provided. Defaults to 192.
         delta (int): size of the border cropped from each chip. Defaults to 8.
@@ -396,11 +664,40 @@ def tiled_inference(
         h_stride (int, optional): size of the stride on the y-axis.
         w_stride (int, optional): size of the stride on the x-axis.
         average_patches (bool): Whether to average the overlapping regions. Defaults to True.
+        blend_overlaps (bool): Whether to use blend masks on overlapping edges. Defaults to True.
         batch_size (int): Number of chips per forward pass. Defaults to 16.
-        padding (str | bool): Padding mode for input image to reduce artefacts on edges. Deactivate padding with False.
-            Defaults to reflect.
+        verbose (bool): Show a tqdm progress bar. Defaults to False.
+        padding (str | bool): Padding mode for input image to reduce artefacts on edges.
+            Deactivate padding with False. Defaults to reflect.
+        device (str | None): Device for inference. Inferred from *input_batch* when not given.
+        source (TileSource | None): Optional callable that returns the chip tensor for a
+            given :class:`InferenceInput` descriptor.  When provided, the
+            ``input_data`` stored on the descriptor (which comes from the
+            pre-sliced *input_batch*) is ignored in favour of what the source
+            returns.  This enables on-demand, out-of-core reading.
+
+            The source receives the full :class:`InferenceInput` (including
+            ``input_coords``) so it can map coordinates to a file window.
+            It must return a CPU tensor of shape ``(C, H, W)`` or
+            ``(C, T, H, W)``.
+
+            When *source* is given, *input_batch* can be a dummy tensor that
+            carries only shape / device metadata (``source`` is responsible for
+            the actual data), or it can still be the real tensor – the source
+            will simply override the chip data.
+        sink (TileSink | None): Optional object that receives each predicted
+            chip via :meth:`~TileSink.write` and is asked to produce the final
+            result via :meth:`~TileSink.finalize`.  Use this to write
+            predictions incrementally (e.g. to a GeoTIFF) instead of building
+            a large in-memory accumulator.
+
+            When *sink* is ``None`` (the default) an :class:`InMemoryTileSink`
+            is used, which replicates the original behaviour.
+
     Returns:
-        torch.Tensor: The result of the inference
+        torch.Tensor | None: The result of the inference, or ``None`` if the
+        *sink* returns ``None`` from :meth:`~TileSink.finalize` (e.g. because
+        it writes directly to disk).
     """
 
     if inference_parameters is not None:
@@ -448,7 +745,24 @@ def tiled_inference(
         )
     )
 
-    outputs: list[tuple[InferenceInput, torch.Tensor]] = []
+    # Resolve source: default to reading pre-sliced chip from the descriptor.
+    effective_source: TileSource = source if source is not None else InMemoryTileSource()
+
+    # Resolve sink: default to the classic in-memory accumulator.
+    effective_sink: TileSink
+    if sink is not None:
+        effective_sink = sink
+    else:
+        effective_sink = InMemoryTileSink(
+            input_batch_size=input_batch_size,
+            h_img=h_img,
+            w_img=w_img,
+            delta=delta,
+            device=device,
+            padding=padding,
+            average_patches=average_patches,
+        )
+
     # NOTE: the output may be SLIGHTLY different using batched inputs because of layers such as nn.LayerNorm
     # During inference, these layers compute batch statistics that affect the output.
     # However, this should still be correct.
@@ -458,22 +772,16 @@ def tiled_inference(
         ):
             end = min(len(coordinates_and_inputs), start + batch_size)
             batch = coordinates_and_inputs[start:end]
-            tensor_input = torch.stack([b.input_data for b in batch], dim=0)
+
+            # Read chip data via the source (custom or default in-memory).
+            chip_tensors = [effective_source(chip) for chip in batch]
+            tensor_input = torch.stack(chip_tensors, dim=0)
             tensor_input = tensor_input.to(device)
             tensor_input = tensor_reshape(tensor_input)  # Optional reshaping for inputs other than plain tensors
             output = model_forward(tensor_input, **kwargs).cpu()
-            output = [output[i] for i in range(len(batch))]
 
-            outputs.extend(list(zip(batch, output, strict=True)))
+            # Dispatch each chip's prediction to the sink.
+            for i, chip in enumerate(batch):
+                effective_sink.write(chip, output[i])
 
-    output = generate_tiled_inference_output(
-        outputs=outputs,
-        input_batch_size=input_batch_size,
-        h_img=h_img,
-        w_img=w_img,
-        delta=delta,
-        padding=padding,
-        average_patches=average_patches,
-    )
-
-    return output.to(device)
+    return effective_sink.finalize()

--- a/tests/test_tiled_inference.py
+++ b/tests/test_tiled_inference.py
@@ -1,0 +1,315 @@
+# Copyright contributors to the Terratorch project
+"""Unit tests for terratorch/tasks/tiled_inference.py
+
+Tests cover:
+  * The unchanged (default) in-memory path – behavioural parity with the old API.
+  * Custom TileSource – chips are read on demand; the result equals the default path.
+  * Custom TileSink   – predictions are streamed to the sink; finalize() is called once.
+  * Sink that returns None – tiled_inference propagates None to the caller.
+  * Protocol isinstance checks for TileSource / TileSink.
+"""
+
+import torch
+import pytest
+
+from terratorch.tasks.tiled_inference import (
+    InferenceInput,
+    InMemoryTileSource,
+    InMemoryTileSink,
+    TileSource,
+    TileSink,
+    tiled_inference,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_identity_model(out_channels: int = 2):
+    """Return a callable that produces a fixed output tensor of shape (B, C, H, W).
+
+    The output values are the mean of all channels in the input, broadcast to
+    ``out_channels`` – simple enough to reason about while still exercising the
+    blend/average logic.
+    """
+
+    def model(x: torch.Tensor, **kwargs) -> torch.Tensor:
+        # x: (B, C, H, W)
+        mean = x.float().mean(dim=1, keepdim=True)  # (B, 1, H, W)
+        return mean.expand(-1, out_channels, -1, -1)
+
+    return model
+
+
+def _image(batch: int = 1, channels: int = 4, h: int = 256, w: int = 256) -> torch.Tensor:
+    torch.manual_seed(42)
+    return torch.rand(batch, channels, h, w)
+
+
+# ---------------------------------------------------------------------------
+# Default (in-memory) path – backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultPath:
+    """The new default path should produce the same result as the old implementation."""
+
+    def test_basic_returns_tensor(self):
+        img = _image()
+        model = _make_identity_model(out_channels=3)
+        result = tiled_inference(model, img, h_crop=64, w_crop=64, h_stride=48, w_stride=48, delta=4)
+        assert isinstance(result, torch.Tensor)
+        assert result.shape == (1, 3, 256, 256)
+
+    def test_output_shape_matches_input(self):
+        batch, c = 2, 6
+        img = _image(batch=batch, channels=c, h=128, w=192)
+        model = _make_identity_model(out_channels=4)
+        result = tiled_inference(model, img, h_crop=64, w_crop=64, h_stride=48, w_stride=48, delta=4)
+        assert result.shape == (batch, 4, 128, 192)
+
+    def test_no_padding_mode(self):
+        img = _image(h=128, w=128)
+        model = _make_identity_model(out_channels=2)
+        result = tiled_inference(
+            model, img, h_crop=64, w_crop=64, h_stride=48, w_stride=48, delta=0, padding=False
+        )
+        assert result.shape == (1, 2, 128, 128)
+
+    def test_small_image_single_forward(self):
+        """Images that fit in one crop must trigger a single forward without tiling."""
+        calls = []
+
+        def model(x, **kwargs):
+            calls.append(x.shape)
+            return x[:, :2]
+
+        img = _image(h=32, w=32)
+        result = tiled_inference(model, img, h_crop=64, w_crop=64)
+        assert len(calls) == 1  # exactly one pass
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# InMemoryTileSource
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryTileSource:
+    def test_returns_input_data(self):
+        chip_data = torch.rand(4, 64, 64)
+        tile = InferenceInput(
+            batch=0,
+            input_coords=(slice(0, 56), slice(0, 56)),
+            input_data=chip_data,
+            blend_mask=torch.ones(56, 56),
+            output_crop=(slice(4, 60), slice(4, 60)),
+        )
+        source = InMemoryTileSource()
+        out = source(tile)
+        assert out is chip_data  # same object, no copy
+
+    def test_isinstance_protocol(self):
+        assert isinstance(InMemoryTileSource(), TileSource)
+
+
+# ---------------------------------------------------------------------------
+# Custom TileSource – on-demand reading
+# ---------------------------------------------------------------------------
+
+
+class _TensorBackedSource:
+    """Simulates an out-of-core source: reads chips from a big in-memory tensor
+    but only when asked (like a rasterio dataset would).
+    """
+
+    def __init__(self, full_image: torch.Tensor):
+        # full_image: (B, C, H, W)  – already padded if needed
+        self._img = full_image
+        self.calls: list[tuple[int, tuple]] = []
+
+    def __call__(self, tile: InferenceInput) -> torch.Tensor:
+        r, c = tile.input_coords
+        # We need the chip window, not the output window.
+        # For the test we'll just return the pre-sliced input_data so that
+        # results are identical to the default path.
+        self.calls.append((tile.batch, (r, c)))
+        return tile.input_data  # reuse pre-sliced data for comparison
+
+
+class TestCustomSource:
+    def test_custom_source_called_for_every_chip(self):
+        img = _image(h=128, w=128)
+        src = _TensorBackedSource(img)
+        model = _make_identity_model(out_channels=2)
+
+        result = tiled_inference(
+            model, img, h_crop=64, w_crop=64, h_stride=48, w_stride=48, delta=4, source=src
+        )
+        assert len(src.calls) > 0
+        assert result.shape == (1, 2, 128, 128)
+
+    def test_custom_source_result_matches_default(self):
+        """When custom source returns the same data as the default, outputs must be identical."""
+        img = _image(h=128, w=128)
+
+        # Source that returns the same chip data stored on the descriptor
+        class PassthroughSource:
+            def __call__(self, tile: InferenceInput) -> torch.Tensor:
+                return tile.input_data
+
+        model = _make_identity_model(out_channels=2)
+        params = dict(h_crop=64, w_crop=64, h_stride=48, w_stride=48, delta=4, padding="reflect")
+
+        result_default = tiled_inference(model, img, **params)
+        result_custom = tiled_inference(model, img, **params, source=PassthroughSource())
+
+        assert torch.allclose(result_default, result_custom, atol=1e-5)
+
+    def test_isinstance_protocol(self):
+        img = _image()
+        src = _TensorBackedSource(img)
+        assert isinstance(src, TileSource)
+
+
+# ---------------------------------------------------------------------------
+# InMemoryTileSink
+# ---------------------------------------------------------------------------
+
+
+class TestInMemoryTileSink:
+    def test_single_chip_no_padding(self):
+        h_img, w_img = 56, 56
+        sink = InMemoryTileSink(
+            input_batch_size=1,
+            h_img=h_img,
+            w_img=w_img,
+            delta=0,
+            device="cpu",
+            padding=False,
+            average_patches=True,
+        )
+        pred = torch.ones(3, 56, 56)
+        blend = torch.ones(56, 56)
+        tile = InferenceInput(
+            batch=0,
+            input_coords=(slice(0, 56), slice(0, 56)),
+            input_data=pred,
+            blend_mask=blend,
+            output_crop=None,
+        )
+        sink.write(tile, pred)
+        result = sink.finalize()
+        assert result.shape == (1, 3, 56, 56)
+        assert torch.allclose(result, torch.ones(1, 3, 56, 56))
+
+    def test_finalize_raises_if_empty(self):
+        sink = InMemoryTileSink(1, 64, 64, 0, "cpu", False, True)
+        with pytest.raises(RuntimeError, match="No chips were written"):
+            sink.finalize()
+
+    def test_isinstance_protocol(self):
+        sink = InMemoryTileSink(1, 64, 64, 0, "cpu", False, True)
+        assert isinstance(sink, TileSink)
+
+
+# ---------------------------------------------------------------------------
+# Custom TileSink – streaming output
+# ---------------------------------------------------------------------------
+
+
+class _CollectingSink:
+    """Sink that stores every (tile, prediction) pair for later inspection."""
+
+    def __init__(self):
+        self.received: list[tuple[InferenceInput, torch.Tensor]] = []
+        self._finalized = False
+
+    def write(self, tile: InferenceInput, prediction: torch.Tensor) -> None:
+        self.received.append((tile, prediction.clone()))
+
+    def finalize(self):
+        self._finalized = True
+        return None  # signals "I handle my own output"
+
+
+class TestCustomSink:
+    def test_write_called_per_chip(self):
+        img = _image(h=128, w=128)
+        custom_sink = _CollectingSink()
+        model = _make_identity_model(out_channels=2)
+
+        result = tiled_inference(
+            model, img, h_crop=64, w_crop=64, h_stride=48, w_stride=48, delta=4, sink=custom_sink
+        )
+        assert result is None  # sink returned None
+        assert custom_sink._finalized
+        assert len(custom_sink.received) > 0  # at least one chip
+
+    def test_custom_sink_predictions_on_cpu(self):
+        """Predictions dispatched to the sink must already be on CPU."""
+        img = _image(h=128, w=128)
+
+        class DeviceCheckSink:
+            def __init__(self):
+                self.devices = []
+
+            def write(self, tile, pred):
+                self.devices.append(pred.device)
+
+            def finalize(self):
+                return None
+
+        checker = DeviceCheckSink()
+        model = _make_identity_model(out_channels=2)
+        tiled_inference(model, img, h_crop=64, w_crop=64, h_stride=48, w_stride=48, delta=4, sink=checker)
+
+        assert all(str(d) == "cpu" for d in checker.devices)
+
+    def test_isinstance_protocol(self):
+        assert isinstance(_CollectingSink(), TileSink)
+
+    def test_sink_result_matches_default(self):
+        """A sink that does the same averaging as InMemoryTileSink must produce identical output."""
+        img = _image(h=128, w=128)
+        model = _make_identity_model(out_channels=2)
+        params = dict(h_crop=64, w_crop=64, h_stride=48, w_stride=48, delta=4, padding="reflect")
+
+        default_result = tiled_inference(model, img, **params)
+
+        # Build a manual sink that mirrors InMemoryTileSink
+        manual_sink = InMemoryTileSink(
+            input_batch_size=1,
+            h_img=128,
+            w_img=128,
+            delta=4,
+            device="cpu",
+            padding="reflect",
+            average_patches=True,
+        )
+        custom_result = tiled_inference(model, img, **params, sink=manual_sink)
+
+        assert torch.allclose(default_result, custom_result, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Source + Sink combined
+# ---------------------------------------------------------------------------
+
+
+class TestSourceAndSinkCombined:
+    def test_source_and_sink_together(self):
+        """Using both a custom source and a custom sink must not raise."""
+        img = _image(h=128, w=128)
+        src = _TensorBackedSource(img)
+        snk = _CollectingSink()
+        model = _make_identity_model(out_channels=2)
+
+        result = tiled_inference(
+            model, img, h_crop=64, w_crop=64, h_stride=48, w_stride=48, delta=4, source=src, sink=snk
+        )
+        assert result is None
+        assert len(snk.received) > 0
+        assert len(src.calls) == len(snk.received)


### PR DESCRIPTION
Introduces two optional Protocol-based plug-in points to tiled_inference()
that decouple chip reading and prediction writing from the in-memory tensor
path, enabling inference on images too large to fit in RAM.

- TileSource: callable protocol; return a chip tensor on demand (e.g. from
  a rasterio window) instead of reading from a pre-loaded tensor
- TileSink: write() + finalize() protocol; stream predictions directly to
  disk instead of accumulating them in a large in-memory buffer
- InMemoryTileSource / InMemoryTileSink: default implementations that
  reproduce the original behaviour exactly so no breaking changes
- input_batch is now optional (None allowed when a custom source is used)
- tiled_inference() return type broadened to Tensor | None to support sinks
  that write to external stores and return None from finalise()
  
  #1199