### PR TITLE
Bump version to v1.2.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["terratorch*"]
 
 [project]
 name = "terratorch"
-version = "v1.2.10"
+version = "v1.2.11"
 description = "TerraTorch - The geospatial foundation model fine-tuning toolkit"
 license = "Apache-2.0 AND MIT"
 license-files = ["LICENSE", "MIT_FILES.txt"]


### PR DESCRIPTION
Ships the `torch.load(weights_only=True)` security hardening from #1212, which addresses the arbitrary-code-execution advisory GHSA-6qgg-frm7-fc93 (CWE-502, CVSS 7.8). The fix is on `main` but not yet in a released version; the latest release (v1.2.10) is still vulnerable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)