### PR TITLE
Skip geobench_v2 test when optional dep is not installed

### DIFF
--- a/tests/test_geobench_v2_data_module.py
+++ b/tests/test_geobench_v2_data_module.py
@@ -2,6 +2,8 @@ import gc
 
 import pytest
 
+pytest.importorskip("geobench_v2", reason="geobench_v2 optional dependency is not installed")
+
 from terratorch.datamodules import geobench_v2_data_module as gmod
 
 


### PR DESCRIPTION
`tests/test_geobench_v2_data_module.py` imports `geobench_v2` (via `terratorch.datamodules.geobench_v2_data_module`) at module scope. Since the `geobenchv2` optional dependency was dropped from the default test extras in #1208, collection fails with `ModuleNotFoundError: No module named 'geobench_v2'`, turning the tuning-toolkit `build (3.13)` job red on every PR against `main`.

Guard the import with `pytest.importorskip("geobench_v2", ...)`, matching the existing `rfdetr` pattern in `test_detr.py`, so the module skips cleanly when the optional dep is absent and still runs when it's installed.

Pre-existing failure, independent of any release work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)