### PR TITLE
Add GFM Swin Encoder

### DIFF
--- a/docs/package/backbones.md
+++ b/docs/package/backbones.md
@@ -30,6 +30,27 @@
     options:
         toc_label: "Clay v1"
 
+:::terratorch.models.backbones.gfm_swin.gfm_swin_base
+    options:
+        toc_label: "GFM Swin"
+
+!!! tip
+    `gfm_swin_base` returns NCHW features, so unlike the other Swin backbones it needs no
+    `PermuteDims` neck to feed decoders such as `UperNetDecoder`:
+
+    ```yaml
+    model:
+      init_args:
+        model_args:
+          backbone: gfm_swin_base
+          backbone_pretrained: true
+          backbone_model_bands:
+            - RED
+            - GREEN
+            - BLUE
+          decoder: UperNetDecoder
+    ```
+
 ## APIs for External Models
 
 !!! tip

--- a/terratorch/models/backbones/__init__.py
+++ b/terratorch/models/backbones/__init__.py
@@ -4,6 +4,7 @@
 import terratorch.models.backbones.clay_v1
 import terratorch.models.backbones.dinov3
 import terratorch.models.backbones.dofa_vit
+import terratorch.models.backbones.gfm_swin
 import terratorch.models.backbones.identity_backbone
 import terratorch.models.backbones.mmearth_convnextv2
 import terratorch.models.backbones.prithvi_swin

--- a/terratorch/models/backbones/gfm_swin.py
+++ b/terratorch/models/backbones/gfm_swin.py
@@ -1,0 +1,274 @@
+# reference implementation https://github.com/mmendiet/GFM
+# "Towards Geospatial Foundation Models via Continual Pretraining" (arXiv:2302.04476)
+
+import logging
+import sys
+import types
+from collections import OrderedDict
+
+import torch
+from huggingface_hub import hf_hub_download
+from torch import nn
+
+from terratorch.datasets.utils import HLSBands, generate_bands_intervals
+from terratorch.models.backbones.prithvi_swin import convert_weights_swin2mmseg
+from terratorch.models.backbones.select_patch_embed_weights import select_patch_embed_weights
+from terratorch.models.backbones.swin_encoder_decoder import MMSegSwinTransformer
+from terratorch.registry import TERRATORCH_BACKBONE_REGISTRY
+
+logger = logging.getLogger(__name__)
+
+# GFM was pretrained on GeoPile, which is RGB only.
+GFM_PRETRAINED_BANDS = [HLSBands.RED, HLSBands.GREEN, HLSBands.BLUE]
+
+GFM_HF = {"repo_id": "torchgeo/gfm", "filename": "gfm.pth"}
+
+GFM_SWIN_BASE_ARGS = {
+    "pretrain_img_size": 192,
+    "patch_size": 4,
+    "window_size": 6,
+    "embed_dim": 128,
+    "depths": (2, 2, 18, 2),
+    "num_heads": (4, 8, 16, 32),
+}
+
+GFM_OUT_CHANNELS = [128, 256, 512, 1024]
+
+# The upstream checkpoint carries SimMIM pretraining artifacts and a teacher branch
+# that have no counterpart in MMSegSwinTransformer.
+_ENCODER_PREFIX = "encoder."
+
+# mmseg's Swin builds a norm per stage, which the upstream checkpoint does not carry, and a
+# classifier head, which an encoder never uses. nn.LayerNorm default-initializes to weight=1
+# and bias=0, i.e. exactly the identity, so the absent stage norms are deterministic rather
+# than randomly initialized. Verified: models built under different seeds produce bitwise
+# identical features.
+_ALLOWED_MISSING_SUFFIXES = ("norm.weight", "norm.bias")
+_ALLOWED_MISSING_KEYS = {"head.fc.weight", "head.fc.bias"}
+
+
+def _install_yacs_stub() -> None:
+    """Make the GFM checkpoint unpicklable without depending on `yacs`.
+
+    The upstream checkpoint stores its training config as a pickled `yacs.config.CfgNode`,
+    so `torch.load` needs that symbol to be importable. `yacs` is not a TerraTorch
+    dependency and should not become one, since the config is discarded anyway. A stub is
+    registered only when `yacs` is genuinely absent, via `setdefault`, so a real
+    installation is never shadowed.
+    """
+    if "yacs" in sys.modules or "yacs.config" in sys.modules:
+        return
+
+    try:
+        # Deliberately lazy: this probes whether a real yacs is installed.
+        import yacs.config  # noqa: F401, PLC0415
+    except ImportError:
+        pass
+    else:
+        return
+
+    yacs_module = types.ModuleType("yacs")
+    config_module = types.ModuleType("yacs.config")
+
+    class CfgNode(dict):
+        """Minimal stand-in for `yacs.config.CfgNode`, sufficient to unpickle and discard."""
+
+    config_module.CfgNode = CfgNode
+    yacs_module.config = config_module
+
+    sys.modules.setdefault("yacs", yacs_module)
+    sys.modules.setdefault("yacs.config", config_module)
+
+
+def _load_gfm_checkpoint(ckpt_data: str) -> dict[str, torch.Tensor]:
+    """Load the raw upstream GFM checkpoint and return its `model` state dict.
+
+    Args:
+        ckpt_data (str): Local path, or an `https://hf.co/<repo>/resolve/<rev>/<file>` URL.
+
+    Returns:
+        The `model` entry, discarding optimizer / lr_scheduler / config / amp state.
+    """
+    if ckpt_data.find("https://hf.co/") > -1:
+        repo_id = ckpt_data.split("/resolve/", maxsplit=1)[0].replace("https://hf.co/", "")
+        filename = ckpt_data.rsplit("/", maxsplit=1)[-1]
+        ckpt_data = hf_hub_download(repo_id=repo_id, filename=filename)
+
+    _install_yacs_stub()
+
+    # weights_only=True cannot read this checkpoint: it stores a pickled yacs CfgNode.
+    checkpoint = torch.load(ckpt_data, map_location="cpu", weights_only=False)
+
+    if not isinstance(checkpoint, dict) or "model" not in checkpoint:
+        msg = (
+            f"Expected a GFM checkpoint containing a 'model' key, but got "
+            f"{sorted(checkpoint.keys()) if isinstance(checkpoint, dict) else type(checkpoint).__name__}."
+        )
+        raise ValueError(msg)
+
+    return checkpoint["model"]
+
+
+def gfm_checkpoint_filter_fn(
+    state_dict: dict[str, torch.Tensor],
+    model: nn.Module,
+    pretrained_bands: list,
+    model_bands: list,
+) -> OrderedDict:
+    """Convert an upstream GFM state dict into MMSegSwinTransformer naming.
+
+    The upstream `model` dict holds four branches: `encoder.*` (the student, which is what we
+    want), `teacher.*` (the EMA branch), and `decoder.*` / `projector.*` (pretraining heads).
+
+    Args:
+        state_dict: The upstream `model` state dict, or a full checkpoint containing `model`.
+        model: The target model, used for patch embed band selection.
+        pretrained_bands: Bands the checkpoint was pretrained on.
+        model_bands: Bands the model is being built for.
+
+    Returns:
+        A state dict using mmseg key names, restricted to the encoder.
+    """
+    if "model" in state_dict:
+        state_dict = state_dict["model"]
+
+    # Keep the student encoder; drop teacher/decoder/projector.
+    encoder_state_dict = OrderedDict()
+    for k, v in state_dict.items():
+        if not k.startswith(_ENCODER_PREFIX):
+            continue
+        stripped = k[len(_ENCODER_PREFIX) :]
+        # mask_token is a SimMIM pretraining artifact; attn_mask buffers are non-persistent.
+        if stripped == "mask_token" or stripped.endswith("attn_mask"):
+            continue
+        encoder_state_dict[stripped] = v
+
+    # Renames Microsoft-Swin names to mmseg names, and critically permutes
+    # downsample.reduction / downsample.norm to mmseg's PatchMerging unfold order.
+    # Skipping that permutation loads without error but silently yields wrong features.
+    converted = convert_weights_swin2mmseg(encoder_state_dict)
+
+    # GFM's single final norm has no mmseg counterpart (mmseg norms per stage instead).
+    for key in ("norm.weight", "norm.bias"):
+        converted.pop(key, None)
+
+    logger.info(f"GFM checkpoint: kept {len(converted)} encoder tensors.")
+    logger.info(
+        "The per-stage norms are absent from the GFM checkpoint and initialize to the "
+        "identity (LayerNorm weight=1, bias=0), so features are deterministic."
+    )
+
+    return select_patch_embed_weights(converted, model, pretrained_bands, model_bands)
+
+
+class GFMSwinEncoderWrapper(nn.Module):
+    """Wraps MMSegSwinTransformer to emit a standard BCHW feature pyramid.
+
+    `MMSegSwinTransformer.forward_features` returns only the last stage's tuple, because
+    `stages` is an `nn.Sequential`, so this wrapper iterates the stages itself to collect
+    every level. Each stage returns `(normed_NHWC, hw_shape, downsampled, down_hw_shape)`
+    and consumes a single `(tokens, hw_shape)` tuple.
+
+    Unlike `satlas_swin_*` and `prithvi_swin_*`, the output is already NCHW, so no
+    `PermuteDims` neck is needed to feed decoders such as `UperNetDecoder`.
+    """
+
+    def __init__(self, swin_model: MMSegSwinTransformer, out_indices: tuple | list = (0, 1, 2, 3)) -> None:
+        """
+        Args:
+            swin_model (MMSegSwinTransformer): The backbone module to be wrapped.
+            out_indices (tuple | list): Indices of the stages whose features are returned.
+        """
+        super().__init__()
+        self.model = swin_model
+        self.out_indices = tuple(out_indices)
+
+        # EncoderDecoderFactory requires out_channels, and infers patch_size by scanning
+        # submodules -- MMSegSwinTransformer's patch_embed does not expose one.
+        self.out_channels = [c for i, c in enumerate(GFM_OUT_CHANNELS) if i in self.out_indices]
+        self.patch_size = GFM_SWIN_BASE_ARGS["patch_size"]
+
+    def forward(self, x: torch.Tensor, **kwargs) -> list[torch.Tensor]:  # noqa: ARG002
+        outs = []
+        stage_input = self.model.patch_embed(x)
+        for i, stage in enumerate(self.model.stages):
+            normed, _, downsampled, down_hw_shape = stage(stage_input)
+            if i in self.out_indices:
+                outs.append(normed.permute(0, 3, 1, 2).contiguous())
+            stage_input = (downsampled, down_hw_shape)
+
+        return outs
+
+
+@TERRATORCH_BACKBONE_REGISTRY.register
+def gfm_swin_base(
+    model_bands: list | None = None,
+    pretrained: bool = False,  # noqa: FBT001, FBT002
+    ckpt_data: str | None = None,
+    out_indices: tuple | list = (0, 1, 2, 3),
+    **kwargs,
+) -> GFMSwinEncoderWrapper:
+    """GFM Swin-B encoder, pretrained on GeoPile via continual pretraining.
+
+    Reference: "Towards Geospatial Foundation Models via Continual Pretraining"
+    (arXiv:2302.04476), https://github.com/mmendiet/GFM. Weights are Apache-2.0 and
+    distributed as `torchgeo/gfm` on the Hugging Face Hub.
+
+    Returns a four-level BCHW feature pyramid with channels [128, 256, 512, 1024] at strides
+    [4, 8, 16, 32]. Because the output is already NCHW, this backbone needs no `PermuteDims`
+    neck in `EncoderDecoderFactory`.
+
+    Preprocessing: scale inputs to [0, 1], then normalize with ImageNet statistics,
+    mean (0.485, 0.456, 0.406) and std (0.229, 0.224, 0.225).
+
+    Pretraining used 192x192 RGB imagery. There is no absolute position embedding, so larger
+    input sizes work without interpolation. Requesting bands beyond RGB is supported and
+    follows the usual TerraTorch convention: pretrained RGB weights are placed at the matching
+    band positions and any additional band is randomly initialized, which reinterprets an
+    RGB-only patch embedding.
+
+    The checkpoint carries no per-stage norms. Those initialize to the identity
+    (LayerNorm weight=1, bias=0), so results do not depend on the random seed.
+
+    Args:
+        model_bands (list): Bands the model is built for. Defaults to RGB.
+        pretrained (bool): Whether to load the pretrained weights.
+        ckpt_data (str | None): Path or hf.co URL of a checkpoint, taking precedence over the
+            Hugging Face download.
+        out_indices (tuple | list): Indices of the stages whose features are returned.
+
+    Returns:
+        GFMSwinEncoderWrapper
+    """
+    if model_bands is None:
+        model_bands = GFM_PRETRAINED_BANDS
+    model_bands = [HLSBands.try_convert_to_hls_bands_enum(b) for b in model_bands]
+    model_bands = generate_bands_intervals(model_bands)
+
+    kwargs["in_chans"] = len(model_bands)
+
+    model = MMSegSwinTransformer(**GFM_SWIN_BASE_ARGS, **kwargs)
+
+    if pretrained or ckpt_data is not None:
+        if ckpt_data is None:
+            ckpt_data = hf_hub_download(**GFM_HF)
+        checkpoint = _load_gfm_checkpoint(ckpt_data)
+        checkpoint = gfm_checkpoint_filter_fn(checkpoint, model, GFM_PRETRAINED_BANDS, model_bands)
+        missing_keys, unexpected_keys = model.load_state_dict(checkpoint, strict=False)
+
+        if unexpected_keys:
+            msg = f"Unexpected keys when loading the GFM checkpoint: {sorted(unexpected_keys)}"
+            raise ValueError(msg)
+
+        unaccounted = [
+            k for k in missing_keys if k not in _ALLOWED_MISSING_KEYS and not k.endswith(_ALLOWED_MISSING_SUFFIXES)
+        ]
+        if unaccounted:
+            msg = f"Missing keys when loading the GFM checkpoint: {sorted(unaccounted)}"
+            raise ValueError(msg)
+
+    encoder = GFMSwinEncoderWrapper(model, out_indices=out_indices)
+    encoder.model_bands = model_bands
+    encoder.pretrained_bands = GFM_PRETRAINED_BANDS
+
+    return encoder

--- a/tests/test_encoder_decoder_torchgeo_models.py
+++ b/tests/test_encoder_decoder_torchgeo_models.py
@@ -195,3 +195,30 @@ def test_create_pixelwise_model_swin(backbone, task, expected, decoder, model_fa
         assert model(model_input).output.shape == expected
 
     gc.collect()
+
+
+@pytest.mark.parametrize("task,expected", PIXELWISE_TASK_EXPECTED_OUTPUT)
+@pytest.mark.parametrize("decoder", ["UperNetDecoder", "UNetDecoder"])
+def test_create_pixelwise_model_gfm_swin(task, expected, decoder, model_factory: EncoderDecoderFactory, model_input):
+    """GFM emits NCHW directly, so unlike the other Swin backbones it needs no PermuteDims neck."""
+    model_args = {
+        "task": task,
+        "backbone": "gfm_swin_base",
+        "decoder": decoder,
+        "backbone_model_bands": PRETRAINED_BANDS,
+        "backbone_pretrained": False,
+    }
+
+    if task == "segmentation":
+        model_args["num_classes"] = NUM_CLASSES
+
+    if decoder == "UNetDecoder":
+        model_args["decoder_channels"] = [512, 256, 128, 64]
+
+    model = model_factory.build_model(**model_args)
+    model.eval()
+
+    with torch.no_grad():
+        assert model(model_input).output.shape == expected
+
+    gc.collect()

--- a/tests/test_gfm_swin.py
+++ b/tests/test_gfm_swin.py
@@ -1,0 +1,240 @@
+# Copyright contributors to the Terratorch project
+import gc
+from collections import OrderedDict
+
+import pytest
+import torch
+
+from terratorch.datasets.utils import HLSBands, generate_bands_intervals
+from terratorch.models.backbones.gfm_swin import (
+    GFM_OUT_CHANNELS,
+    GFM_PRETRAINED_BANDS,
+    GFM_SWIN_BASE_ARGS,
+    _load_gfm_checkpoint,
+    gfm_checkpoint_filter_fn,
+)
+from terratorch.models.backbones.prithvi_swin import convert_weights_swin2mmseg
+from terratorch.models.backbones.swin_encoder_decoder import MMSegSwinTransformer
+from terratorch.registry import BACKBONE_REGISTRY
+
+EXPECTED_PYRAMID = {
+    192: [(1, 128, 48, 48), (1, 256, 24, 24), (1, 512, 12, 12), (1, 1024, 6, 6)],
+    224: [(1, 128, 56, 56), (1, 256, 28, 28), (1, 512, 14, 14), (1, 1024, 7, 7)],
+}
+
+SIX_BANDS = ["BLUE", "GREEN", "RED", "NIR_NARROW", "SWIR_1", "SWIR_2"]
+
+# The GFM checkpoint carries none of these, and they initialize to the identity.
+ALLOWED_MISSING = {f"stages.{i}.norm.{s}" for i in range(4) for s in ("weight", "bias")} | {
+    "head.fc.weight",
+    "head.fc.bias",
+}
+
+
+def _build_swin(in_chans: int = 3) -> MMSegSwinTransformer:
+    return MMSegSwinTransformer(**GFM_SWIN_BASE_ARGS, in_chans=in_chans)
+
+
+def _synthetic_upstream_checkpoint(model: MMSegSwinTransformer) -> dict:
+    """Build a fake upstream GFM checkpoint from a model's own state dict.
+
+    Applies the inverse of the mmseg renames so the result looks like the released
+    checkpoint: an `encoder.*` student, a `teacher.*` branch, pretraining heads, a
+    SimMIM `mask_token`, and non-persistent `attn_mask` buffers.
+    """
+    upstream = OrderedDict()
+    for key, value in model.state_dict().items():
+        if key.startswith("head."):
+            continue
+        inverse = key.replace("stages", "layers", 1) if key.startswith("stages") else key
+        inverse = inverse.replace("attn.w_msa.", "attn.")
+        inverse = inverse.replace("ffn.layers.0.0.", "mlp.fc1.").replace("ffn.layers.1.", "mlp.fc2.")
+        inverse = inverse.replace("patch_embed.projection", "patch_embed.proj")
+        upstream[f"encoder.{inverse}"] = value
+        upstream[f"teacher.{inverse}"] = torch.zeros_like(value)
+
+    upstream["encoder.mask_token"] = torch.zeros(1, 1, GFM_SWIN_BASE_ARGS["embed_dim"])
+    upstream["encoder.layers.0.blocks.1.attn_mask"] = torch.zeros(4, 36, 36)
+    upstream["encoder.norm.weight"] = torch.ones(GFM_OUT_CHANNELS[-1])
+    upstream["encoder.norm.bias"] = torch.zeros(GFM_OUT_CHANNELS[-1])
+    upstream["decoder.0.weight"] = torch.zeros(1)
+    upstream["projector.0.weight"] = torch.zeros(1)
+
+    return {"model": upstream}
+
+
+def test_can_create_gfm_swin_from_registry():
+    backbone = BACKBONE_REGISTRY.build("gfm_swin_base", pretrained=False)
+
+    assert backbone.out_channels == GFM_OUT_CHANNELS
+    assert backbone.patch_size == GFM_SWIN_BASE_ARGS["patch_size"]
+
+    gc.collect()
+
+
+@pytest.mark.parametrize("input_size", [192, 224])
+def test_gfm_swin_feature_pyramid(input_size):
+    backbone = BACKBONE_REGISTRY.build("gfm_swin_base", pretrained=False)
+    backbone.eval()  # MMSegSwinTransformer.eval() returns None, so never chain it
+
+    with torch.no_grad():
+        output = backbone(torch.randn(1, 3, input_size, input_size))
+
+    assert isinstance(output, list)
+    assert [tuple(t.shape) for t in output] == EXPECTED_PYRAMID[input_size]
+
+    gc.collect()
+
+
+def test_gfm_swin_out_indices_filters_channels_and_output():
+    backbone = BACKBONE_REGISTRY.build("gfm_swin_base", pretrained=False, out_indices=(1, 3))
+    backbone.eval()
+
+    assert backbone.out_channels == [256, 1024]
+
+    with torch.no_grad():
+        output = backbone(torch.randn(1, 3, 224, 224))
+
+    assert [tuple(t.shape) for t in output] == [(1, 256, 28, 28), (1, 1024, 7, 7)]
+
+    gc.collect()
+
+
+def test_gfm_swin_accepts_non_rgb_bands():
+    backbone = BACKBONE_REGISTRY.build("gfm_swin_base", pretrained=False, model_bands=SIX_BANDS)
+    backbone.eval()
+
+    with torch.no_grad():
+        output = backbone(torch.randn(1, len(SIX_BANDS), 224, 224))
+
+    assert [tuple(t.shape) for t in output] == EXPECTED_PYRAMID[224]
+
+    gc.collect()
+
+
+def test_filter_fn_keeps_only_encoder_and_loads_cleanly():
+    model = _build_swin()
+    checkpoint = _synthetic_upstream_checkpoint(model)
+
+    filtered = gfm_checkpoint_filter_fn(checkpoint, model, GFM_PRETRAINED_BANDS, GFM_PRETRAINED_BANDS)
+
+    assert not any(k.startswith(("teacher", "decoder", "projector")) for k in filtered)
+    assert "mask_token" not in filtered
+    assert not any(k.endswith("attn_mask") for k in filtered)
+    # GFM's single final norm has no mmseg counterpart and must be dropped.
+    assert "norm.weight" not in filtered
+    assert "norm.bias" not in filtered
+
+    missing_keys, unexpected_keys = model.load_state_dict(filtered, strict=False)
+
+    assert unexpected_keys == []
+    assert set(missing_keys) <= ALLOWED_MISSING
+
+    gc.collect()
+
+
+def test_missing_stage_norms_are_seed_independent():
+    """The absent per-stage norms init to the identity, so features must not depend on the seed."""
+    checkpoint = _synthetic_upstream_checkpoint(_build_swin())
+
+    outputs = []
+    for seed in (0, 12345):
+        torch.manual_seed(seed)
+        model = _build_swin()
+        filtered = gfm_checkpoint_filter_fn(checkpoint, model, GFM_PRETRAINED_BANDS, GFM_PRETRAINED_BANDS)
+        model.load_state_dict(filtered, strict=False)
+        model.eval()
+
+        with torch.no_grad():
+            stage_input = model.patch_embed(torch.ones(1, 3, 192, 192))
+            features = []
+            for stage in model.stages:
+                normed, _, downsampled, down_hw_shape = stage(stage_input)
+                features.append(normed)
+                stage_input = (downsampled, down_hw_shape)
+        outputs.append(features)
+
+    for first, second in zip(outputs[0], outputs[1], strict=True):
+        assert torch.equal(first, second)
+
+    gc.collect()
+
+
+def test_convert_weights_permutes_downsample():
+    """Regression guard: mmseg's PatchMerging needs a [0, 2, 1, 3] reordering, not a copy.
+
+    Skipping the permutation loads without error but silently produces wrong features, so
+    assert the converter actually reorders. Tested through the public outer function because
+    the correct_unfold_* helpers are nested closures.
+    """
+    reduction = torch.randn(8, 16)
+    norm = torch.randn(16)
+    converted = convert_weights_swin2mmseg(
+        OrderedDict(
+            {
+                "layers.0.downsample.reduction.weight": reduction,
+                "layers.0.downsample.norm.weight": norm,
+            }
+        )
+    )
+
+    new_reduction = converted["stages.0.downsample.reduction.weight"]
+    new_norm = converted["stages.0.downsample.norm.weight"]
+
+    assert not torch.equal(new_reduction, reduction)
+    assert not torch.equal(new_norm, norm)
+    # A permutation preserves the multiset of values.
+    assert torch.equal(new_reduction.flatten().sort().values, reduction.flatten().sort().values)
+    assert torch.equal(new_norm.sort().values, norm.sort().values)
+
+    expected_norm = norm.reshape(4, 4)[[0, 2, 1, 3], :].transpose(0, 1).reshape(16)
+    assert torch.equal(new_norm, expected_norm)
+
+    gc.collect()
+
+
+def test_pretrained_bands_land_in_correct_positions():
+    """RGB weights must map onto the requested band positions, with extra bands initialized fresh."""
+    source = _build_swin()
+    checkpoint = _synthetic_upstream_checkpoint(source)
+    original_proj = source.state_dict()["patch_embed.projection.weight"]
+
+    model = _build_swin(in_chans=len(SIX_BANDS))
+    model_bands = generate_bands_intervals([HLSBands.try_convert_to_hls_bands_enum(b) for b in SIX_BANDS])
+    filtered = gfm_checkpoint_filter_fn(checkpoint, model, GFM_PRETRAINED_BANDS, model_bands)
+
+    proj = filtered["patch_embed.projection.weight"]
+    assert proj.shape == (GFM_SWIN_BASE_ARGS["embed_dim"], len(SIX_BANDS), 4, 4)
+
+    # GFM_PRETRAINED_BANDS is [RED, GREEN, BLUE]; SIX_BANDS starts [BLUE, GREEN, RED].
+    for model_position, pretrained_index in ((0, 2), (1, 1), (2, 0)):
+        assert torch.equal(proj[:, model_position], original_proj[:, pretrained_index])
+
+    # Bands absent from pretraining get fresh weights rather than copied RGB.
+    for extra_position in (3, 4, 5):
+        assert not any(torch.equal(proj[:, extra_position], original_proj[:, i]) for i in range(3))
+
+    gc.collect()
+
+
+def test_malformed_checkpoint_raises(tmp_path):
+    path = tmp_path / "bad.pth"
+    torch.save({"not_model": {}}, path)
+
+    with pytest.raises(ValueError, match="model"):
+        _load_gfm_checkpoint(str(path))
+
+    gc.collect()
+
+
+@pytest.mark.slow
+def test_gfm_swin_pretrained_downloads_from_hf():
+    backbone = BACKBONE_REGISTRY.build("gfm_swin_base", pretrained=True)
+    backbone.eval()
+
+    with torch.no_grad():
+        output = backbone(torch.randn(1, 3, 192, 192))
+
+    assert [tuple(t.shape) for t in output] == EXPECTED_PYRAMID[192]
+
+    gc.collect()


### PR DESCRIPTION
Adds the GFM Swin-B encoder, an RGB only model,  to the backbone registry, usable from EncoderDecoderFactory 

- Paper:  [Towards Geospatial Foundation Models via Continual Pretraining](https://arxiv.org/abs/2302.04476) (arXiv:2302.04476)  
- Repo: https://github.com/mmendiet/GFM 
- Weights: [torchgeo/gfm](https://huggingface.co/torchgeo/gfm) (Apache-2.0)


- Registers gfm_swin_base, wrapping MMSegSwinTransformer to return a four-level BCHW pyramid — channels [128, 256, 512, 1024] at strides [4, 8, 16, 32].
- No PermuteDims neck required, unlike satlas_swin_* and prithvi_swin_* which emit NHWC — verified with UperNetDecoder and UNetDecoder.
- checkpoint rehosted at https://huggingface.co/torchgeo/gfm
- The 8 missing per-stage LayerNorms are harmless. mmseg's Swin has a norm per stage that the GFM checkpoint does not carry, so they stay at PyTorch's default init — weight=1, bias=0, 