### PR TITLE
Fix DDP deadlock with CombinedLoss (#982)

### DIFF
--- a/terratorch/tasks/loss_handler.py
+++ b/terratorch/tasks/loss_handler.py
@@ -93,12 +93,17 @@ class LossHandler:
         full_loss = all_losses.pop("loss")
         log_function(f"{self.loss_prefix}loss", full_loss, sync_dist=True, batch_size=batch_size)
 
+        # Log the individual component losses (present when using a CombinedLoss) with the same
+        # settings as the total loss above, i.e. letting Lightning pick on_step/on_epoch from the
+        # hook context (on_step during training, on_epoch during validation/test). Forcing both
+        # on_step=True and on_epoch=True here previously caused DDP to deadlock at the end of the
+        # first epoch, because the extra epoch-level synced reduction was only triggered for the
+        # component losses and not for the total loss, desynchronising the collective calls across
+        # ranks. See https://github.com/IBM/terratorch/issues/982.
         for loss_name, loss_value in all_losses.items():
             log_function(
                 f"{self.loss_prefix}{loss_name}",
                 loss_value,
-                on_epoch=True,
-                on_step=True,
                 sync_dist=True,
                 batch_size=batch_size,
             )

--- a/tests/test_loss_handler.py
+++ b/tests/test_loss_handler.py
@@ -1,0 +1,75 @@
+# Copyright contributors to the Terratorch project
+"""Tests for terratorch.tasks.loss_handler.
+
+Regression coverage for https://github.com/IBM/terratorch/issues/982: logging the individual
+component losses of a CombinedLoss must not force ``on_step``/``on_epoch``. Doing so made DDP
+deadlock at the end of the first epoch, because the extra epoch-level synced reduction fired only
+for the component losses (and not for the total loss), desynchronising the collective calls across
+ranks.
+"""
+import torch
+
+from terratorch.tasks.loss_handler import CombinedLoss, LossHandler
+
+
+def _capture_logs(loss_dict, prefix="train/"):
+    """Run log_loss with a fake log_function and return the recorded calls."""
+    calls = []
+
+    def fake_log(name, value, **kwargs):
+        calls.append({"name": name, "value": value, "kwargs": kwargs})
+
+    handler = LossHandler(prefix)
+    handler.log_loss(fake_log, loss_dict=loss_dict, batch_size=4)
+    return calls
+
+
+def test_single_loss_logs_only_total():
+    calls = _capture_logs({"loss": torch.tensor(1.0)})
+    assert [c["name"] for c in calls] == ["train/loss"]
+    # No on_step/on_epoch forced; Lightning defaults are used.
+    assert "on_step" not in calls[0]["kwargs"]
+    assert "on_epoch" not in calls[0]["kwargs"]
+    assert calls[0]["kwargs"]["sync_dist"] is True
+
+
+def test_combined_loss_component_logging_does_not_force_step_epoch():
+    loss_dict = {
+        "loss": torch.tensor(6.0),
+        "ce": torch.tensor(1.0),
+        "dice": torch.tensor(5.0),
+    }
+    calls = _capture_logs(loss_dict)
+
+    names = [c["name"] for c in calls]
+    assert names == ["train/loss", "train/ce", "train/dice"]
+
+    # The core of the #982 regression guard: no component (nor the total) may force on_step /
+    # on_epoch, so DDP collectives stay symmetric across all logged values.
+    for c in calls:
+        assert "on_step" not in c["kwargs"], f"{c['name']} must not force on_step"
+        assert "on_epoch" not in c["kwargs"], f"{c['name']} must not force on_epoch"
+        assert c["kwargs"]["sync_dist"] is True
+        assert c["kwargs"]["batch_size"] == 4
+
+
+def test_log_loss_does_not_mutate_input_dict():
+    loss_dict = {"loss": torch.tensor(2.0), "ce": torch.tensor(1.0)}
+    _capture_logs(loss_dict)
+    assert set(loss_dict.keys()) == {"loss", "ce"}
+
+
+def test_combined_loss_forward_produces_component_and_total_keys():
+    """CombinedLoss returns each named component plus an aggregated "loss" key, and those keys
+    are exactly what log_loss emits (total first, then one entry per component)."""
+    combined = CombinedLoss({"ce": torch.nn.CrossEntropyLoss(), "ce2": torch.nn.CrossEntropyLoss()})
+    logits = torch.randn(2, 3, 8, 8)
+    target = torch.randint(0, 3, (2, 8, 8))
+
+    out = combined(logits, target)
+    assert set(out.keys()) == {"loss", "ce", "ce2"}
+    # Unweighted CombinedLoss sums the components.
+    torch.testing.assert_close(out["loss"], out["ce"] + out["ce2"])
+
+    calls = _capture_logs(out)
+    assert [c["name"] for c in calls] == ["train/loss", "train/ce", "train/ce2"]


### PR DESCRIPTION
## Summary

Fixes #982 — `trainer.fit()` hangs at the end of the first epoch when training with a `CombinedLoss` (e.g. `{"ce": 1.0, "dice": 5.0}`) across **more than one GPU**. A single loss works fine.

## Root cause

In `LossHandler.log_loss`, the **total** loss is logged with Lightning's default `on_step`/`on_epoch` behaviour (context-dependent), but each **individual component** loss was logged with `on_step=True, on_epoch=True` forced, together with `sync_dist=True`:

```python
log_function(f"{self.loss_prefix}loss", full_loss, sync_dist=True, batch_size=batch_size)  # defaults
for loss_name, loss_value in all_losses.items():
    log_function(..., on_epoch=True, on_step=True, sync_dist=True, ...)  # forced both
```

The forced epoch-level **synchronized** reduction fired only for the component losses and not for the total loss. That asymmetry desynchronised the DDP collective calls across ranks, deadlocking at the first epoch boundary. Single losses never enter the component loop, which is exactly why only `CombinedLoss` was affected.

This matches the debugging by @matteot11 and @bhansaliraunak in the issue thread.

## Fix

Log the component losses with the **same** settings as the total loss — letting Lightning pick `on_step`/`on_epoch` from the hook context (`on_step` during training, `on_epoch` during validation/test), keeping `sync_dist=True`. This is the recommended Lightning behaviour and keeps the collectives symmetric across ranks.

Note on @blumenstiel's point about keeping both step- and epoch-level monitoring: the default per-hook behaviour already gives per-step curves during training and epoch-averaged values during validation, which is the usual monitoring setup. Forcing both on the components is precisely what deadlocks, so it can't be retained as-is.

## Tests

Adds `tests/test_loss_handler.py` — a regression guard asserting that neither the total nor the component losses force `on_step`/`on_epoch`, that logging doesn't mutate the caller's dict, and that `CombinedLoss` component keys line up with what gets logged.

## Validation

Ran on the IBM BlueVela LSF cluster (Python 3.12): **`tests/test_loss_handler.py` — 4 passed**.

_Note: a true 2-GPU hang/no-hang reproduction of the original script would be the ideal end-to-end check; I validated the logging contract that caused the desync. Reviewers with a multi-GPU box can confirm the original repro from the issue now completes._

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>