### PR TITLE
Pin torchgeo to >=0.9.0,<0.10 to fix fresh-install import break (#912)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,10 @@ dependencies = [
   "lightning>=2.6.0",
   "segmentation-models-pytorch>=0.5.0",
   "jsonargparse>=4.40.0",
-  "torchgeo", #>=0.7.0,<0.7.2",
+  # torchgeo 0.10 removed torchgeo.trainers.utils (imported in timm_model_factory.py)
+  # and made other breaking API changes; 0.9.x is the verified-compatible line. Without
+  # an upper bound a fresh install resolves 0.10 and fails at import. See issue #912.
+  "torchgeo>=0.9.0,<0.10",
   "einops",
   "timm>=1.0.15",
   "pycocotools",


### PR DESCRIPTION
## What

Pins `torchgeo` to `>=0.9.0,<0.10` in `pyproject.toml` (it was previously declared unbounded as `"torchgeo"`).

## Why

`torchgeo` **0.10.0** removed `torchgeo.trainers.utils`, which terratorch imports in [`terratorch/models/timm_model_factory.py`](https://github.com/torchgeo/terratorch/blob/main/terratorch/models/timm_model_factory.py) (`from torchgeo.trainers import utils`), along with other breaking API changes. Because the dependency had no upper bound, a from-scratch install resolves the latest (0.10.0) and dies at import before any test runs:

```
ImportError: cannot import name 'utils' from 'torchgeo.trainers'
```

This is what makes the `build (3.13)` and `rfdetr-tests (3.13)` CI jobs red on recent PRs (27 collection errors on the former, 1 on the latter), and it prevents anyone from reproducing the test environment locally per #912.

## Verification

- `torchgeo 0.9.0` satisfies the new spec and `from torchgeo.trainers import utils` imports cleanly.
- The `<0.10` bound excludes the broken 0.10.0.
- The full unit suite (**1603 passed**) and the integration base set (**16 passed**) were run against 0.9.0 on the BlueVela cluster while validating #982/#1219.

Refs #912.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
