### PR TITLE
CI: install tortilla extra so tacoreader is available in tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -56,7 +56,7 @@ jobs:
         run: |
           pip install pip==25.1
           pip --version
-          pip install -e .[test] -c constraints/test-py313.txt
+          pip install -e .[test,tortilla] -c constraints/test-py313.txt
       - name: List pip dependencies
         run: pip list
       - name: Test with pytest (fast)
@@ -89,7 +89,7 @@ jobs:
         run: |
           pip install pip==25.1
           pip --version
-          pip install -e .[test] -c constraints/test-py313.txt
+          pip install -e .[test,tortilla] -c constraints/test-py313.txt
       - name: Test with pytest (slow)
         run: |
           pytest -s -v -m "slow" tests


### PR DESCRIPTION
## Problem

The `tests.yaml` **build** and **slow-tests** jobs are failing on 3 tests in `tests/test_tortilla_dataset.py`, all with:

```
tacoreader is required to use tortilla files. Install it with: pip install terratorch[tortilla]
```

`main` is currently red for this reason (last several scheduled runs failed), and it surfaces on open PRs (e.g. #1229) as an unrelated failing check.

## Root cause

`tacoreader` lives only in the `tortilla` optional-dependency extra (`tacoreader>=2.4.0`). CI installs `.[test]`, which does **not** include it, and `test_tortilla_dataset.py` has no `importorskip` guard — so the datamodule fails to load and the tests hard-fail rather than skip.

## Fix

Add `tortilla` to the pip install for the `build` and `slow-tests` jobs (`.[test]` → `.[test,tortilla]`). `tacoreader>=2.4.0` (latest 2.4.21) supports `>=3.10,<3.14`, so it resolves on the 3.13 CI matrix. The `rfdetr-tests` job is left unchanged (it only runs `test_detr.py`).

Note: local validation on my machine is blocked because my venv is Python 3.14 (outside tacoreader's `<3.14` range); CI runs 3.13, where the extra installs. CI on this PR is the validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)