### PR TITLE
CI: don't fail slow-tests when no slow tests are collected

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -92,7 +92,10 @@ jobs:
           pip install -e .[test,tortilla] -c constraints/test-py313.txt
       - name: Test with pytest (slow)
         run: |
-          pytest -s -v -m "slow" tests
+          # pytest exit code 5 == "no tests collected". The only slow-marked tests
+          # (test_detr.py) require the rfdetr extra and run in the rfdetr-tests job,
+          # so nothing is selected here; treat 5 as success instead of failing the job.
+          pytest -s -v -m "slow" tests || [ "$?" -eq 5 ]
 
   rfdetr-tests:
     environment: cicd


### PR DESCRIPTION
## Problem

The `slow-tests` job in `tests.yaml` fails on every scheduled/dispatch run, keeping the nightly build red even though nothing is actually broken.

Log shows: `1633 deselected / 2 skipped / 0 selected` → pytest exits **5 ("no tests collected")**, which GitHub treats as a job failure.

## Why nothing is selected

The only `slow`-marked tests are in `test_detr.py` (`pytestmark = pytest.mark.slow`), and those require the `rfdetr` extra — which `slow-tests` doesn't install. They already run in the dedicated `rfdetr-tests` job, so `pytest -m slow` here selects 0 tests.

## Fix

Treat exit code 5 as success:

```
pytest -s -v -m "slow" tests || [ "$?" -eq 5 ]
```

A genuine slow-test failure (any non-zero, non-5 exit) still fails the job. This only stops an empty selection from going red.

Follow-up to #1230 (which fixed the `build`/`slow-tests` tortilla install). Note `slow-tests` is gated to non-PR events, so this affects scheduled/dispatch runs, not PR checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)