### PR TITLE
Fix datetime module/class shadow in segmentation IO processor

### DIFF
--- a/terratorch/vllm/plugins/segmentation/segmentation_io_processor.py
+++ b/terratorch/vllm/plugins/segmentation/segmentation_io_processor.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import copy
-import datetime
 import logging
 import os
 import tempfile
@@ -319,7 +318,7 @@ class SegmentationIOProcessor(IOProcessor):
                     if len(julian_day) == 3:
                         julian_day = int(julian_day)
                     else:
-                        julian_day = datetime.datetime.strptime(julian_day, "%m%d").timetuple().tm_yday
+                        julian_day = datetime.strptime(julian_day, "%m%d").timetuple().tm_yday
                     temporal_coords.append([year, julian_day])
             except Exception:
                 logger.exception("Could not extract timestamp for %s", file)


### PR DESCRIPTION
## Problem

In `terratorch/vllm/plugins/segmentation/segmentation_io_processor.py` the imports contained both:

```python
import datetime                    # module
from datetime import datetime      # class — shadows the module
```

The `from` import shadows the plain module import, so the name `datetime` always refers to the **class**. That broke one of the two call sites:

- `load_image()` called `datetime.datetime.strptime(...)` → `AttributeError: type object 'datetime.datetime' has no attribute 'datetime'` whenever a filename timestamp used the 4-digit `MMDD` julian-day form.
- `pre_process_async()` called `datetime.now()`, which only works because `datetime` is the class.

The two call sites had contradictory expectations, so at least one was always wrong.

## Fix

Drop the redundant `import datetime` module import and call `datetime.strptime(...)` directly. Both call sites now consistently use the class. One-line change plus removing the dead import.

## Testing

- `python -m py_compile` passes.
- Verified `datetime.strptime('0715','%m%d').timetuple().tm_yday` and `datetime.now()` both work with only the class imported, and that the old `datetime.datetime` access raises `AttributeError` (the bug).

This is a pre-existing bug on `main`, independent of the vLLM 0.27 plugin update (#1229).

🤖 Generated with [Claude Code](https://claude.com/claude-code)