### PR TITLE
Bump version to v1.2.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["terratorch*"]
 
 [project]
 name = "terratorch"
-version = "v1.2.11"
+version = "v1.2.12"
 description = "TerraTorch - The geospatial foundation model fine-tuning toolkit"
 license = "Apache-2.0 AND MIT"
 license-files = ["LICENSE", "MIT_FILES.txt"]


### PR DESCRIPTION
Release **v1.2.12**.

Notable changes since v1.2.11:
- Remove `scale_modules` from UPerNet decoder (#1095) — note: this required re-publishing the `Prithvi-EO-2.0-300M-TL-Sen1Floods11` HF checkpoint (migrated to the `LearnedInterpolateToPyramidal` neck) so it loads again.
- Fix DDP deadlock with `CombinedLoss` (#982 / #1219).
- Pin torchgeo `>=0.9.0,<0.10` to fix fresh-install import break (#912).
- Pinned test constraints for a reproducible test environment (#912).
- Upgrade tacoreader to support TerraKit `.tacozip` (#1210); install the tortilla extra in CI (#1230).
- Don't fail slow-tests when no slow tests are collected (#1231).
- Pluggable source/sink API for larger-tile inference.
- `SklearnDecoder` + `EmbeddingClassificationTask` for sklearn-based classification on frozen embeddings.

Integration test suite confirmed green on BlueVela (all 8 jobs passed).

Merging this triggers the tag + PyPI publish per the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)