### PR TITLE
fix: keep decoder_scale_modules configs and checkpoints loading (#109…

### DIFF
--- a/docs/guide/encoder_decoder_factory.md
+++ b/docs/guide/encoder_decoder_factory.md
@@ -92,6 +92,28 @@ Not all encoders and decoders are compatible. Below we include some caveats.
 Some decoders expect pyramidal outputs, but some encoders do not produce such outputs (e.g. vanilla ViT models).
 In this case, the [InterpolateToPyramidal][terratorch.models.necks.InterpolateToPyramidal], [MaxpoolToPyramidal][terratorch.models.necks.MaxpoolToPyramidal] and [LearnedInterpolateToPyramidal][terratorch.models.necks.LearnedInterpolateToPyramidal] necks may be particularly useful.
 
+### Migrating from `decoder_scale_modules`
+
+`UperNetDecoder` used to build the pyramidal projections itself when `decoder_scale_modules: true`
+was passed. That option was removed: the same modules are now provided by the
+[LearnedInterpolateToPyramidal][terratorch.models.necks.LearnedInterpolateToPyramidal] neck.
+
+Old configs keep working. `decoder_scale_modules: true` appends that neck automatically and emits a
+deprecation warning, and checkpoints that stored those weights as `decoder.fpn1` ... `decoder.fpn4`
+are remapped onto the neck while loading, so published models load unchanged. To migrate a config,
+drop `decoder_scale_modules` and append the neck explicitly:
+
+```yaml
+model_args:
+  decoder: UperNetDecoder
+  decoder_channels: 256
+  necks:
+    - name: SelectIndices
+      indices: [5, 11, 17, 23]
+    - name: ReshapeTokensToImage
+    - name: LearnedInterpolateToPyramidal  # replaces decoder_scale_modules: true
+```
+
 ### SMP decoders
 
 Not all decoders are guaranteed to work with all encoders without additional necks.

--- a/docs/guide/vllm/prepare_your_model.md
+++ b/docs/guide/vllm/prepare_your_model.md
@@ -55,6 +55,9 @@ The snippet below shows the structure of the `config.json` file for a Prithvi
             },
             {
               "name": "ReshapeTokensToImage"
+            },
+            {
+              "name": "LearnedInterpolateToPyramidal"
             }
           ]
         },
@@ -183,6 +186,9 @@ follows the standard format for a TerraTorch model configuration.
         },
         {
           "name": "ReshapeTokensToImage"
+        },
+        {
+          "name": "LearnedInterpolateToPyramidal"
         }
       ]
     },

--- a/examples/datasets_and_benchmarks/chesapeake_dataset_prithvi.yaml
+++ b/examples/datasets_and_benchmarks/chesapeake_dataset_prithvi.yaml
@@ -80,13 +80,17 @@ model:
     model_factory: EncoderDecoderFactory
     model_args:
       backbone: prithvi_eo_tiny
-      backbone_out_indices:
-        - 2
-        - 5
-        - 8
-        - 11
       decoder: UperNetDecoder
       decoder_channels: 128
+      necks:
+        - name: SelectIndices
+          indices:
+            - 2
+            - 5
+            - 8
+            - 11
+        - name: ReshapeTokensToImage
+        - name: LearnedInterpolateToPyramidal
       backbone_bands:
       - RED
       - GREEN

--- a/terratorch/models/encoder_decoder_factory.py
+++ b/terratorch/models/encoder_decoder_factory.py
@@ -1,5 +1,6 @@
 # Copyright contributors to the Terratorch project
 
+import inspect
 import logging
 import warnings
 from typing import List
@@ -14,11 +15,11 @@ from terratorch.models.model import (
     Model,
     ModelFactory,
 )
-from terratorch.models.necks import Neck, NeckSequential, build_neck_list
+from terratorch.models.necks import LearnedInterpolateToPyramidal, Neck, NeckSequential, build_neck_list
 from terratorch.models.peft_utils import get_peft_backbone
 from terratorch.models.pixel_wise_model import PixelWiseModel
 from terratorch.models.scalar_output_model import ScalarOutputModel
-from terratorch.models.utils import TemporalWrapper, extract_prefix_keys
+from terratorch.models.utils import TemporalWrapper, extract_prefix_keys, register_legacy_scale_modules_hook
 from terratorch.registry import BACKBONE_REGISTRY, DECODER_REGISTRY, MODEL_FACTORY_REGISTRY
 
 from .utils import _get_backbone
@@ -82,6 +83,57 @@ def _get_decoder_and_head_kwargs(
             head_kwargs[key] = num_outputs
 
     return DECODER_REGISTRY.build(decoder, channel_list, **decoder_kwargs), head_kwargs, includes_head
+
+
+SCALE_MODULES_KEY = "scale_modules"
+SCALE_MODULES_NECK = "LearnedInterpolateToPyramidal"
+SCALE_MODULES_DEPRECATION_MSG = (
+    "`decoder_scale_modules` is deprecated and was removed from UperNetDecoder. A "
+    f"`{SCALE_MODULES_NECK}` neck was appended to `necks` instead, which builds the very same "
+    "modules and produces the same output. Update your config to declare that neck explicitly "
+    "and drop `decoder_scale_modules`."
+)
+SCALE_MODULES_REDUNDANT_MSG = (
+    "`decoder_scale_modules` is deprecated and was ignored, because `necks` already declares a "
+    f"`{SCALE_MODULES_NECK}` neck. Drop `decoder_scale_modules` from your config."
+)
+
+
+def _decoder_handles_scale_modules(decoder: str | nn.Module | None) -> bool:
+    """Whether the decoder still accepts `scale_modules` itself, so no migration is needed."""
+    if decoder is None or isinstance(decoder, nn.Module):
+        return False
+    try:
+        decoder_class = DECODER_REGISTRY.find_class(decoder)
+        return SCALE_MODULES_KEY in inspect.signature(decoder_class).parameters
+    except Exception:  # noqa: BLE001 - unknown decoders are handled further down the line
+        return False
+
+
+def _pop_scale_modules(decoder_kwargs: dict | None, kwargs: dict) -> tuple[bool, dict | None]:
+    """Drop the deprecated scale_modules flag, reporting whether it was enabled.
+
+    `kwargs` is this factory's own dict and is edited in place; `decoder_kwargs` belongs to the
+    caller, so a copy without the flag is returned instead.
+    """
+    enabled = bool(kwargs.pop(f"decoder_{SCALE_MODULES_KEY}", False))
+    if decoder_kwargs and SCALE_MODULES_KEY in decoder_kwargs:
+        enabled = bool(decoder_kwargs[SCALE_MODULES_KEY]) or enabled
+        decoder_kwargs = {k: v for k, v in decoder_kwargs.items() if k != SCALE_MODULES_KEY}
+    return enabled, decoder_kwargs
+
+
+def _uses_aux_scale_modules(aux_decoders: list[AuxiliaryHead] | None) -> bool:
+    """Whether any auxiliary decoder enables the deprecated scale_modules flag.
+
+    The flag is not removed here: auxiliary arguments are copied further down, so it is dropped
+    from that copy rather than from the caller's dict.
+    """
+    return any(
+        (aux_decoder.decoder_args or {}).get(f"decoder_{SCALE_MODULES_KEY}", False)
+        and not _decoder_handles_scale_modules(aux_decoder.decoder)
+        for aux_decoder in aux_decoders or []
+    )
 
 
 def _check_all_args_used(kwargs):
@@ -199,6 +251,21 @@ class EncoderDecoderFactory(ModelFactory):
 
         if necks is None:
             necks = []
+
+        # backwards compatibility: configs and checkpoints predating the removal of
+        # `UperNetDecoder(scale_modules=True)` are migrated to the equivalent neck
+        scale_modules = False
+        if not _decoder_handles_scale_modules(decoder):
+            scale_modules, decoder_kwargs = _pop_scale_modules(decoder_kwargs, kwargs)
+            scale_modules = _uses_aux_scale_modules(aux_decoders) or scale_modules
+        if scale_modules:
+            if any(neck.get("name") == SCALE_MODULES_NECK for neck in necks):
+                # the config was migrated already, the leftover flag would scale the features twice
+                warnings.warn(SCALE_MODULES_REDUNDANT_MSG, DeprecationWarning, stacklevel=2)
+            else:
+                warnings.warn(SCALE_MODULES_DEPRECATION_MSG, DeprecationWarning, stacklevel=2)
+                necks = [*necks, {"name": SCALE_MODULES_NECK}]
+
         neck_list, channel_list = build_neck_list(necks, out_channels)
 
         # some decoders already include a head
@@ -236,6 +303,9 @@ class EncoderDecoderFactory(ModelFactory):
                 args = aux_decoder.decoder_args if aux_decoder.decoder_args else {}
                 aux_decoder_kwargs, args = extract_prefix_keys(args, "decoder_")
                 aux_head_kwargs, args = extract_prefix_keys(args, "head_")
+                if not _decoder_handles_scale_modules(aux_decoder.decoder):
+                    # already handled by the neck the main decoder migration appended
+                    aux_decoder_kwargs.pop(SCALE_MODULES_KEY, None)
                 aux_decoder_instance, aux_head_kwargs, aux_decoder_includes_head = _get_decoder_and_head_kwargs(
                     aux_decoder.decoder,
                     channel_list,
@@ -298,8 +368,10 @@ def _build_appropriate_model(
         neck_module: nn.Module = NeckSequential(*necks)
     else:
         neck_module = None
+
+    model = None
     if task in PIXEL_WISE_TASKS:
-        return PixelWiseModel(
+        model = PixelWiseModel(
             task,
             backbone,
             decoder,
@@ -313,7 +385,7 @@ def _build_appropriate_model(
             auxiliary_heads=auxiliary_heads,
         )
     elif task in SCALAR_TASKS:
-        return ScalarOutputModel(
+        model = ScalarOutputModel(
             task,
             backbone,
             decoder,
@@ -326,9 +398,25 @@ def _build_appropriate_model(
         )
 
     elif task in EMBEDDING_GENERATION:
-        return EmbeddingOutputModel(
+        model = EmbeddingOutputModel(
             backbone,
             patch_size=patch_size,
             padding=padding,
             neck=neck_module,
         )
+
+    if model is not None:
+        _support_legacy_scale_modules_checkpoints(model, necks)
+
+    return model
+
+
+def _support_legacy_scale_modules_checkpoints(model: nn.Module, necks: list[Neck] | None) -> None:
+    """Accept checkpoints that stored the pyramidal projections inside the decoder.
+
+    Before `scale_modules` was removed from UperNetDecoder, those weights were saved as
+    `decoder.fpn1` ... `decoder.fpn4`. They belong to the `LearnedInterpolateToPyramidal` neck now.
+    """
+    neck_indices = [i for i, neck in enumerate(necks or []) if isinstance(neck, LearnedInterpolateToPyramidal)]
+    if len(neck_indices) == 1:
+        register_legacy_scale_modules_hook(model, neck_indices[0])

--- a/terratorch/models/utils.py
+++ b/terratorch/models/utils.py
@@ -12,6 +12,40 @@ class DecoderNotFoundError(Exception):
     pass
 
 
+# Modules the removed `UperNetDecoder(scale_modules=True)` used to create inside the decoder.
+# They are now provided by the `LearnedInterpolateToPyramidal` neck.
+LEGACY_SCALE_MODULE_NAMES = ("fpn1", "fpn2", "fpn3", "fpn4")
+
+
+def register_legacy_scale_modules_hook(model: nn.Module, neck_index: int) -> None:
+    """Make checkpoints trained with the removed `scale_modules` option loadable.
+
+    Those checkpoints store the pyramidal projections as `decoder.fpn1` ... `decoder.fpn4`.
+    The very same modules are now built by the `LearnedInterpolateToPyramidal` neck, so their
+    weights are renamed to `neck.<neck_index>.fpn*` while the state dict is being loaded.
+
+    Args:
+        model (nn.Module): Model owning both the `neck` and the `decoder` submodules.
+        neck_index (int): Position of the `LearnedInterpolateToPyramidal` neck in the neck sequence.
+    """
+
+    decoder = getattr(model, "decoder", None)
+
+    def rename_legacy_scale_modules(state_dict, prefix, *args, **kwargs):  # noqa: ARG001
+        for name in LEGACY_SCALE_MODULE_NAMES:
+            if hasattr(decoder, name):
+                # this decoder owns a module of that name, the weights are not the neck's
+                continue
+            legacy_prefix = f"{prefix}decoder.{name}."
+            neck_prefix = f"{prefix}neck.{neck_index}.{name}."
+            for key in [k for k in state_dict if k.startswith(legacy_prefix)]:
+                value = state_dict.pop(key)
+                # a key already stored under the neck name always wins over the legacy one
+                state_dict.setdefault(neck_prefix + key[len(legacy_prefix) :], value)
+
+    model._register_load_state_dict_pre_hook(rename_legacy_scale_modules)
+
+
 def extract_prefix_keys(d: dict, prefix: str) -> dict:
     extracted_dict = {}
     remaining_dict = {}

--- a/tests/test_legacy_scale_modules.py
+++ b/tests/test_legacy_scale_modules.py
@@ -1,0 +1,276 @@
+# Copyright contributors to the Terratorch project
+
+"""Backwards compatibility for the `scale_modules` option removed from UperNetDecoder.
+
+Configs and checkpoints published before the removal set `decoder_scale_modules: true` and store
+the pyramidal projections as `decoder.fpn1` ... `decoder.fpn4`. Both must keep working: the flag
+is migrated to a `LearnedInterpolateToPyramidal` neck and the weights are renamed while loading.
+"""
+
+import gc
+import warnings
+from contextlib import contextmanager
+
+import pytest
+import torch
+from torch import nn
+
+from terratorch.models import EncoderDecoderFactory
+from terratorch.models.backbones.prithvi_vit import PRETRAINED_BANDS
+from terratorch.models.model import AuxiliaryHead
+from terratorch.models.necks import LearnedInterpolateToPyramidal
+
+NUM_CHANNELS = 6
+NUM_CLASSES = 2
+EXPECTED_SEGMENTATION_OUTPUT_SHAPE = (1, NUM_CLASSES, 224, 224)
+
+# the necks published models used together with `decoder_scale_modules`
+LEGACY_NECKS = [
+    {"name": "SelectIndices", "indices": [0, 1, 2, 3]},
+    {"name": "ReshapeTokensToImage"},
+]
+MIGRATED_NECKS = [*LEGACY_NECKS, {"name": "LearnedInterpolateToPyramidal"}]
+
+
+@pytest.fixture(scope="module")
+def model_factory() -> EncoderDecoderFactory:
+    return EncoderDecoderFactory()
+
+
+@pytest.fixture(scope="module")
+def model_input() -> torch.Tensor:
+    return torch.ones((1, NUM_CHANNELS, 224, 224))
+
+
+def _model_args(**overrides) -> dict:
+    args = {
+        "task": "segmentation",
+        "backbone": "prithvi_eo_v2_tiny_tl",
+        "backbone_bands": PRETRAINED_BANDS,
+        "backbone_pretrained": False,
+        "decoder": "UperNetDecoder",
+        "decoder_channels": 256,
+        "num_classes": NUM_CLASSES,
+    }
+    args.update(overrides)
+    return args
+
+
+def _build(model_factory: EncoderDecoderFactory, seed: int, **overrides) -> nn.Module:
+    torch.manual_seed(seed)
+    model = model_factory.build_model(**_model_args(**overrides))
+    model.eval()
+    return model
+
+
+def _to_legacy_checkpoint(state_dict: dict, neck_index: int = 2) -> dict:
+    """Rewrite a current state dict the way it was stored before scale_modules was removed."""
+    neck_prefix = f"neck.{neck_index}.fpn"
+    return {
+        (f"decoder.fpn{k[len(neck_prefix) :]}" if k.startswith(neck_prefix) else k): v
+        for k, v in state_dict.items()
+    }
+
+
+def test_legacy_flag_is_migrated_to_neck(model_factory: EncoderDecoderFactory, model_input):
+    with pytest.warns(DeprecationWarning, match="decoder_scale_modules"):
+        model = _build(model_factory, 0, necks=LEGACY_NECKS, decoder_scale_modules=True)
+
+    assert isinstance(model.neck[-1], LearnedInterpolateToPyramidal)
+    # the decoder no longer owns the projections
+    assert not any(name.startswith(("fpn1", "fpn2", "fpn3", "fpn4")) for name, _ in model.decoder.named_modules())
+
+    with torch.no_grad():
+        assert model(model_input).output.shape == EXPECTED_SEGMENTATION_OUTPUT_SHAPE
+
+    gc.collect()
+
+
+def test_legacy_flag_matches_explicit_neck(model_factory: EncoderDecoderFactory, model_input):
+    """The migrated model must be the very same architecture as the explicit-neck one."""
+    with pytest.warns(DeprecationWarning):
+        legacy = _build(model_factory, 42, necks=LEGACY_NECKS, decoder_scale_modules=True)
+    explicit = _build(model_factory, 43, necks=MIGRATED_NECKS)
+
+    assert set(legacy.state_dict()) == set(explicit.state_dict())
+
+    explicit.load_state_dict(legacy.state_dict())
+    with torch.no_grad():
+        assert torch.equal(legacy(model_input).output, explicit(model_input).output)
+
+    gc.collect()
+
+
+@contextmanager
+def no_deprecation_warning():
+    """Assert the scale_modules deprecation warning is not raised."""
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        yield
+        assert not [r for r in records if "decoder_scale_modules" in str(r.message)]
+
+
+def test_legacy_flag_false_adds_no_neck(model_factory: EncoderDecoderFactory):
+    with no_deprecation_warning():
+        model = _build(model_factory, 0, necks=MIGRATED_NECKS, decoder_scale_modules=False)
+
+    assert len(model.neck) == len(MIGRATED_NECKS)
+
+    gc.collect()
+
+
+@pytest.mark.parametrize("necks", [LEGACY_NECKS, MIGRATED_NECKS])
+def test_legacy_checkpoint_is_remapped(necks, model_factory: EncoderDecoderFactory, model_input):
+    """A checkpoint holding `decoder.fpn*` loads into the neck, from either config style."""
+    scale_modules = necks is LEGACY_NECKS
+    with pytest.warns(DeprecationWarning) if scale_modules else no_deprecation_warning():
+        trained = _build(model_factory, 7, necks=necks, decoder_scale_modules=scale_modules)
+
+    legacy_checkpoint = _to_legacy_checkpoint(trained.state_dict())
+    assert "decoder.fpn1.0.weight" in legacy_checkpoint
+
+    with pytest.warns(DeprecationWarning) if scale_modules else no_deprecation_warning():
+        restored = _build(model_factory, 8, necks=necks, decoder_scale_modules=scale_modules)
+
+    incompatible = restored.load_state_dict(legacy_checkpoint)
+    assert incompatible.missing_keys == []
+    assert incompatible.unexpected_keys == []
+
+    with torch.no_grad():
+        assert torch.equal(trained(model_input).output, restored(model_input).output)
+
+    gc.collect()
+
+
+def test_legacy_checkpoint_is_remapped_under_a_prefix(model_factory: EncoderDecoderFactory, model_input):
+    """Lightning checkpoints store the keys under a `model.` prefix."""
+
+    class Wrapper(nn.Module):
+        def __init__(self, model: nn.Module):
+            super().__init__()
+            self.model = model
+
+    with pytest.warns(DeprecationWarning):
+        trained = _build(model_factory, 11, necks=LEGACY_NECKS, decoder_scale_modules=True)
+    legacy_checkpoint = {f"model.{k}": v for k, v in _to_legacy_checkpoint(trained.state_dict()).items()}
+
+    with pytest.warns(DeprecationWarning):
+        restored = Wrapper(_build(model_factory, 12, necks=LEGACY_NECKS, decoder_scale_modules=True))
+
+    incompatible = restored.load_state_dict(legacy_checkpoint)
+    assert incompatible.missing_keys == []
+    assert incompatible.unexpected_keys == []
+
+    with torch.no_grad():
+        assert torch.equal(trained(model_input).output, restored.model(model_input).output)
+
+    gc.collect()
+
+
+def test_decoder_fpn_convs_are_not_remapped(model_factory: EncoderDecoderFactory):
+    """`fpn_convs` and `fpn_bottleneck` belong to the decoder and must stay there."""
+    with pytest.warns(DeprecationWarning):
+        model = _build(model_factory, 13, necks=LEGACY_NECKS, decoder_scale_modules=True)
+
+    state_dict = model.state_dict()
+    assert any(k.startswith("decoder.fpn_convs") for k in state_dict)
+    incompatible = model.load_state_dict(_to_legacy_checkpoint(state_dict))
+    assert incompatible.missing_keys == []
+    assert incompatible.unexpected_keys == []
+
+    gc.collect()
+
+
+def test_legacy_flag_on_auxiliary_decoder(model_factory: EncoderDecoderFactory, model_input):
+    """Auxiliary decoders read the neck output, so their own flag is dropped as well."""
+    aux_decoders = [
+        AuxiliaryHead(
+            "aux",
+            "UperNetDecoder",
+            {"decoder_channels": 256, "decoder_scale_modules": True},
+        )
+    ]
+    with pytest.warns(DeprecationWarning, match="decoder_scale_modules"):
+        model = _build(
+            model_factory,
+            17,
+            necks=LEGACY_NECKS,
+            decoder_scale_modules=True,
+            aux_decoders=aux_decoders,
+        )
+
+    assert isinstance(model.neck[-1], LearnedInterpolateToPyramidal)
+    with torch.no_grad():
+        output = model(model_input)
+    assert output.output.shape == EXPECTED_SEGMENTATION_OUTPUT_SHAPE
+    assert output.auxiliary_heads["aux"].shape == EXPECTED_SEGMENTATION_OUTPUT_SHAPE
+
+    gc.collect()
+
+
+def test_legacy_flag_is_ignored_when_neck_is_already_declared(model_factory: EncoderDecoderFactory, model_input):
+    """A half-migrated config must not scale the features twice."""
+    with pytest.warns(DeprecationWarning, match="already declares"):
+        model = _build(model_factory, 19, necks=MIGRATED_NECKS, decoder_scale_modules=True)
+
+    assert len(model.neck) == len(MIGRATED_NECKS)
+    assert sum(isinstance(neck, LearnedInterpolateToPyramidal) for neck in model.neck) == 1
+
+    with torch.no_grad():
+        assert model(model_input).output.shape == EXPECTED_SEGMENTATION_OUTPUT_SHAPE
+
+    gc.collect()
+
+
+def test_legacy_flag_leaves_auxiliary_args_untouched(model_factory: EncoderDecoderFactory):
+    """Building twice from the same arguments must give the same model both times."""
+    aux_args = {"decoder_channels": 256, "decoder_scale_modules": True}
+    aux_decoders = [AuxiliaryHead("aux", "UperNetDecoder", aux_args)]
+
+    for _ in range(2):
+        with pytest.warns(DeprecationWarning, match="decoder_scale_modules"):
+            model = _build(model_factory, 23, necks=LEGACY_NECKS, aux_decoders=aux_decoders)
+        assert isinstance(model.neck[-1], LearnedInterpolateToPyramidal)
+
+    assert aux_args == {"decoder_channels": 256, "decoder_scale_modules": True}
+
+    gc.collect()
+
+
+def test_legacy_flag_leaves_decoder_kwargs_untouched(model_factory: EncoderDecoderFactory):
+    """`decoder_kwargs` belongs to the caller and must survive the migration."""
+    decoder_kwargs = {"channels": 256, "scale_modules": True}
+
+    for _ in range(2):
+        with pytest.warns(DeprecationWarning, match="decoder_scale_modules"):
+            model = model_factory.build_model(
+                task="segmentation",
+                backbone="prithvi_eo_v2_tiny_tl",
+                backbone_bands=PRETRAINED_BANDS,
+                backbone_pretrained=False,
+                decoder="UperNetDecoder",
+                decoder_kwargs=decoder_kwargs,
+                num_classes=NUM_CLASSES,
+                necks=LEGACY_NECKS,
+            )
+        assert isinstance(model.neck[-1], LearnedInterpolateToPyramidal)
+
+    assert decoder_kwargs == {"channels": 256, "scale_modules": True}
+
+    gc.collect()
+
+
+def test_decoder_owning_fpn_names_keeps_its_weights(model_factory: EncoderDecoderFactory):
+    """A decoder with its own `fpn1` must keep those weights instead of losing them to the neck."""
+    model = _build(model_factory, 29, necks=MIGRATED_NECKS)
+    # a third-party decoder could legitimately name a submodule `fpn1`
+    model.decoder.fpn1 = nn.Conv2d(4, 4, 1)
+
+    state_dict = model.state_dict()
+    assert "decoder.fpn1.weight" in state_dict
+
+    incompatible = model.load_state_dict(state_dict)
+    assert incompatible.missing_keys == []
+    assert incompatible.unexpected_keys == []
+
+    gc.collect()


### PR DESCRIPTION


PR #1095 removed `scale_modules` from UperNetDecoder without a migration path. Every published model whose config sets `decoder_scale_modules: true` — including ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11 — stopped loading with `UperNetDecoder.__init__() got an unexpected keyword argument 'scale_modules'`, and their checkpoints store those weights as `decoder.fpn1` ... `decoder.fpn4`, which no longer match any module.

EncoderDecoderFactory now migrates the flag to the `LearnedInterpolateToPyramidal` neck, which builds the identical modules, and warns that the option is deprecated. Models carrying that neck also accept the legacy key names: a load-state-dict pre hook renames `decoder.fpn{1..4}` to `neck.<index>.fpn{1..4}`, so published checkpoints load unchanged and no re-upload is needed.

Also restores the pyramidal neck in the two places #1095 dropped the flag without replacing it: the chesapeake example, which raised IndexError at build time, and the vLLM `config.json` snippets, which documented an architecture that cannot load the checkpoint they describe.

Testing
-------
Full suites run on LSF (12 unit shards, 20 integration shards, one GPU each):

  unit        (tests/, 64 files)      1661 passed, 39 skipped, 5 xfailed, 0 failed
  integration (integrationtests/)       58 passed,  0 skipped, 0 xfailed, 0 failed

Real published artifacts, ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11. All four combinations load with no missing or unexpected keys and produce bit-identical output (sha256 407674b372a88fb3...):

  published config (decoder_scale_modules) + published checkpoint (decoder.fpn*)
  published config                         + renamed checkpoint  (neck.2.fpn*)
  migrated config  (explicit neck)         + published checkpoint
  migrated config                          + renamed checkpoint

No behaviour change for configs that do not use the flag: 7 representative models (upernet, unet, fcn, identity/classification, regression, upernet+aux, embedding) build with identical state_dict keys and identical forward output on this branch and on main.

New coverage: tests/test_legacy_scale_modules.py, 12 tests — flag migration, output parity with the explicit neck, legacy checkpoint remapping (bare and `model.` prefixed), the half-migrated config, decoders owning their own fpn names, and non-mutation of caller-supplied kwargs.

Two pre-existing failures were seen and are unrelated: tests/test_tortilla_dataset.py and tests/test_wxc_downscaling_task.py fail identically on main when the `tortilla` and `wxc` extras are absent, and pass once installed.