### PR TITLE
Fix publish workflow: use Python 3.13 (torchgeo>=0.9 needs >=3.12)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.13"
 
       - name: Install build + docs dependencies
         run: |


### PR DESCRIPTION
## Problem

The `v1.2.12` release publish job ([run 33144487456](https://github.com/torchgeo/terratorch/actions/runs/33144487456)) failed at the **Install package** step:

```
ERROR: Could not find a version that satisfies the requirement torchgeo<0.10,>=0.9.0
ERROR: No matching distribution found for torchgeo<0.10,>=0.9.0
```

`torchgeo>=0.9.0` (pinned in #912) requires **Python >=3.12**, but `publish-pypi.yml` set up **Python 3.10**, so pip fell back to torchgeo ≤0.6.2 and could not satisfy the pin. The job failed *before* building or uploading, so **nothing was published to PyPI** and no docs were deployed.

## Fix

Bump the publish workflow's Python to **3.13**, matching the `tests.yaml` CI matrix.

## Follow-up to complete the release

After this merges, the `v1.2.12` tag will be re-pointed to the new main HEAD so the corrected workflow runs and completes the PyPI publish + docs deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)