### PR TITLE
Bump version to v1.2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = ["terratorch*"]
 
 [project]
 name = "terratorch"
-version = "v1.2.12"
+version = "v1.2.13"
 description = "TerraTorch - The geospatial foundation model fine-tuning toolkit"
 license = "Apache-2.0 AND MIT"
 license-files = ["LICENSE", "MIT_FILES.txt"]


### PR DESCRIPTION
Bumps version to v1.2.13.

Includes vLLM plugin support for vllm >= 0.27.0 (#1229), which was missing from the v1.2.12 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)