### PR TITLE
fix(terramind): select_tokens_batched falls back to sample_tokens instead of select_tokens

### DIFF
--- a/terratorch/models/backbones/terramind/model/generate.py
+++ b/terratorch/models/backbones/terramind/model/generate.py
@@ -513,7 +513,7 @@ class GenerationSampler(nn.Module):
             else:
                 return top_samples, top_indices
         else:
-            return self.sample_tokens(logits, num_select, temperature, top_k, top_p, return_all_samples)
+            return self.select_tokens(logits, num_select, temperature, top_k, top_p, return_all_samples)
 
     def forward_mask_encoder_generation(self, encoder_mod_dict):
         """Modification of forward_mask_encoder adapted for generation, with support for batching"""


### PR DESCRIPTION
## Problem

`GenerationSampler.select_tokens_batched` ([`generate.py:501`](https://github.com/torchgeo/terratorch/blob/main/terratorch/models/backbones/terramind/model/generate.py#L501))
handles non-batched (`logits.ndim <= 2`) input by delegating to its non-batched twin —
the same shape as `sample_tokens_batched` right above it. But it calls the **wrong**
twin:

```python
def sample_tokens_batched(self, logits, temperature=1.0, top_k=0.0, top_p=0.0):
    if logits.ndim > 2:
        ...
    else:
        return self.sample_tokens(logits, temperature, top_k, top_p)          # ✅ correct twin

def select_tokens_batched(self, logits, num_select, temperature=1.0, top_k=0.0, top_p=0.0,
                          return_all_samples=False):
    if logits.ndim > 2:
        ...
    else:
        return self.sample_tokens(logits, num_select, temperature, top_k, top_p,
                                  return_all_samples)                          # ❌ should be select_tokens
```

`sample_tokens` is `(self, logits, temperature=1.0, top_k=0.0, top_p=0.0)` — it has no
`num_select` and no `return_all_samples`. The six arguments being passed are precisely
the signature of `select_tokens(self, logits, num_select, temperature=1.0, top_k=0.0,
top_p=0.0, return_all_samples=False)`, which sits between the two, so the intent is
unambiguous.

Result on that branch:

```
TypeError: GenerationSampler.sample_tokens() takes from 2 to 5 positional arguments but 7 were given
```

Today the three in-repo callers (`maskgit_step_batched` and the two CFG variants) always
feed 3-D logits from `forward_enc_dec_maskgit_batched`, so the fallback is latent rather
than hit in the default path — but it is the branch that exists specifically to make
`select_tokens_batched` safe on 2-D input, and right now it is the one input shape it
cannot handle.

## Verification

The four methods' signatures were rebuilt from the real source with `ast` and the
call-site arguments replayed through `inspect.Signature.bind`, using the structurally
identical `sample_tokens_batched` fallback as a control group:

```
sample_tokens         (self, logits, temperature='1.0', top_k='0.0', top_p='0.0')
sample_tokens_batched (self, logits, temperature='1.0', top_k='0.0', top_p='0.0')
select_tokens         (self, logits, num_select, temperature='1.0', top_k='0.0', top_p='0.0', return_all_samples='False')

[PASS] select_tokens_batched fallback (BUG): self.sample_tokens(logits, num_select, temperature, top_k, top_p, return_all_samples)
         bind -> TypeError: too many positional arguments
[PASS] sample_tokens_batched fallback (OK, control): self.sample_tokens(logits, temperature, top_k, top_p)
         bind -> OK
[PASS] AFTER PATCH: self.select_tokens(logits, num_select, temperature, top_k, top_p, return_all_samples)
         bind -> OK
```

## Scope

One line, one word (`sample_tokens` -> `select_tokens`). Identical character count, so
`ruff format` output is unchanged. No signature or behaviour change on any path that
works today.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
